### PR TITLE
feat: add custom equality function support for state primitives

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,11 @@
 	"organizeImports": {
 		"enabled": true
 	},
+	"files": {
+		"ignoreUnknown": true,
+		"include": ["**/*.ts", "**/*.js", "**/*.json"],
+		"ignore": ["tests/template.test.ts", "dist/**/*", "temp/**/*", "node_modules/**/*"]
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -78,10 +83,5 @@
 		"defaultBranch": "trunk",
 		"useIgnoreFile": true,
 		"root": "."
-	},
-	"files": {
-		"ignoreUnknown": true,
-		"include": ["**/*.{ts,js,json}"],
-		"ignore": ["tests/template.test.ts", "dist/**/*", "temp/**/*", "node_modules/**/*"]
 	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "23.10.0"
+node = "23.11.0"
 
 [env]
 NODE_COMPILER_CACHE = "$TMPDIR/.node-cache"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "@nerdalytics/beacon",
-	"version": "1000.1.1",
+	"version": "1000.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nerdalytics/beacon",
-			"version": "1000.1.1",
+			"version": "1000.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "1.9.4",
-				"@types/node": "22.14.0",
+				"@types/node": "22.14.1",
 				"typescript": "5.8.3"
 			},
 			"engines": {
@@ -182,9 +182,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.14.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-			"integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+			"version": "22.14.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nerdalytics/beacon",
-	"version": "1000.1.1",
+	"version": "1000.2.0",
 	"description": "A lightweight reactive state library for Node.js backends. Enables reactive state management with automatic dependency tracking and efficient updates for server-side applications.",
 	"type": "module",
 	"main": "dist/src/index.js",
@@ -34,6 +34,7 @@
 		"test:unit:cyclic-dependency": "node --test tests/cyclic-dependency.test.ts",
 		"test:unit:deep-chain": "node --test tests/deep-chain.test.ts",
 		"test:unit:infinite-loop": "node --test tests/infinite-loop.test.ts",
+		"test:unit:custom-equality": "node --test tests/custom-equality.test.ts",
 		"benchmark": "node scripts/benchmark.ts",
 		"build": "npm run build:lts",
 		"prebuild:lts": "rm -rf dist/",
@@ -66,11 +67,11 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"@types/node": "22.14.0",
+		"@types/node": "22.14.1",
 		"typescript": "5.8.3"
 	},
 	"engines": {
 		"node": ">=20.0.0"
 	},
-	"packageManager": "npm@11.2.0"
+	"packageManager": "npm@11.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
 	"type": "module",
 	"main": "dist/src/index.js",
 	"types": "dist/src/index.d.ts",
-	"files": [
-		"dist/src/index.js",
-		"dist/src/index.d.ts",
-		"src/index.ts",
-		"LICENSE"
-	],
+	"files": ["dist/src/index.js", "dist/src/index.d.ts", "src/index.ts", "LICENSE"],
 	"repository": {
 		"url": "git+https://github.com/nerdalytics/beacon.git",
 		"type": "git"

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,5 +1,5 @@
 import { performance } from 'node:perf_hooks'
-import { state, effect, derive, batch, type State, readonlyState } from '../src/index.ts'
+import { type State, batch, derive, effect, readonlyState, state } from '../src/index.ts'
 
 // Configuration
 const NumIterations = 5 // Number of measurement iterations

--- a/scripts/naiv-benchmark.ts
+++ b/scripts/naiv-benchmark.ts
@@ -1,5 +1,5 @@
 import { performance } from 'node:perf_hooks'
-import { state, effect, derive, batch } from '../src/index.ts'
+import { batch, derive, effect, state } from '../src/index.ts'
 
 const errors = state(0)
 const processed = state(0)

--- a/scripts/naiv-benchmark.ts
+++ b/scripts/naiv-benchmark.ts
@@ -1,131 +1,125 @@
-import { performance } from "node:perf_hooks";
-import { state, effect, derive, batch } from "../src/index.ts";
+import { performance } from 'node:perf_hooks'
+import { state, effect, derive, batch } from '../src/index.ts'
 
-const errors = state(0);
-const processed = state(0);
+const errors = state(0)
+const processed = state(0)
 
 const disposeErrors = effect((): void => {
-	console.debug({ errors: errors() });
-});
+	console.debug({ errors: errors() })
+})
 
 const disposeProcessed = effect((): void => {
-	console.debug({ processed: processed() });
-});
+	console.debug({ processed: processed() })
+})
 
 const incrementErrors = (): void => {
-	errors.set(errors() + 1);
-};
+	errors.set(errors() + 1)
+}
 
 const incrementProcessed = (): void => {
-	processed.set(processed() + 1);
-};
+	processed.set(processed() + 1)
+}
 
-const totals = derive((): number => errors() + processed());
+const totals = derive((): number => errors() + processed())
 
-const LOOP_LENGTH = 1000000;
-const ERROR_FREQUENCY = 1000;
+const LOOP_LENGTH = 1000000
+const ERROR_FREQUENCY = 1000
 
 const signalEffectLoop = ({
 	incrementErrors,
 	incrementProcessed,
 }: {
-	incrementErrors: () => void;
-	incrementProcessed: () => void;
+	incrementErrors: () => void
+	incrementProcessed: () => void
 }): { duration: number } => {
-	const start = performance.now();
-	errors.set(0);
-	processed.set(0);
+	const start = performance.now()
+	errors.set(0)
+	processed.set(0)
 	for (let i = 0; i <= LOOP_LENGTH; i++) {
 		if (i % ERROR_FREQUENCY === 0) {
-			incrementErrors();
+			incrementErrors()
 		} else {
-			incrementProcessed();
+			incrementProcessed()
 		}
 	}
 	if (processed() + errors() !== totals()) {
-		throw new Error(
-			`Error: 'totals()' value differs from 'processed()' + 'errors()' count.`,
-		);
+		throw new Error(`Error: 'totals()' value differs from 'processed()' + 'errors()' count.`)
 	}
-	const end = performance.now();
-	return { duration: end - start };
-};
+	const end = performance.now()
+	return { duration: end - start }
+}
 
 const batchEffectLoop = ({
 	incrementErrors,
 	incrementProcessed,
 }: {
-	incrementErrors: () => void;
-	incrementProcessed: () => void;
+	incrementErrors: () => void
+	incrementProcessed: () => void
 }): { duration: number } => {
-	const start = performance.now();
-	errors.set(0);
-	processed.set(0);
+	const start = performance.now()
+	errors.set(0)
+	processed.set(0)
 	batch((): void => {
 		for (let i = 0; i <= LOOP_LENGTH; i++) {
 			if (i % ERROR_FREQUENCY === 0) {
-				incrementErrors();
-				console.debug({ errors: errors() });
+				incrementErrors()
+				console.debug({ errors: errors() })
 			} else {
-				incrementProcessed();
-				console.debug({ processed: processed() });
+				incrementProcessed()
+				console.debug({ processed: processed() })
 			}
 		}
-	});
+	})
 	if (processed() + errors() !== totals()) {
-		throw new Error(
-			`Error: 'totals()' value differs from 'processed()' + 'errors()' count.`,
-		);
+		throw new Error(`Error: 'totals()' value differs from 'processed()' + 'errors()' count.`)
 	}
-	const end = performance.now();
-	return { duration: end - start };
-};
+	const end = performance.now()
+	return { duration: end - start }
+}
 
 const classicLoop = (): { duration: number } => {
-	const start = performance.now();
-	let errors = 0;
-	let processed = 0;
-	let totals = 0;
+	const start = performance.now()
+	let errors = 0
+	let processed = 0
+	let totals = 0
 	for (let i = 0; i <= LOOP_LENGTH; i++) {
 		if (i % ERROR_FREQUENCY === 0) {
-			console.debug({ errors: errors++ });
+			console.debug({ errors: errors++ })
 		} else {
-			console.debug({ processed: processed++ });
+			console.debug({ processed: processed++ })
 		}
-		totals++;
+		totals++
 	}
 	if (processed + errors !== totals) {
-		throw new Error(
-			`Error: 'totals()' value differs from 'processed()' + 'errors()' count.`,
-		);
+		throw new Error(`Error: 'totals()' value differs from 'processed()' + 'errors()' count.`)
 	}
-	const end = performance.now();
-	return { duration: end - start };
-};
+	const end = performance.now()
+	return { duration: end - start }
+}
 
 const main = (): void => {
 	const signalDuration = signalEffectLoop({
 		incrementErrors,
 		incrementProcessed,
-	});
+	})
 	const batchDuration = batchEffectLoop({
 		incrementErrors,
 		incrementProcessed,
-	});
+	})
 
-	const classicDuration = classicLoop();
+	const classicDuration = classicLoop()
 
 	console.debug({
 		signalDuration,
 		batchDuration,
 		classicDuration,
-	});
+	})
 
-	disposeErrors();
-	disposeProcessed();
-};
+	disposeErrors()
+	disposeProcessed()
+}
 
-main();
+main()
 
 // with fair logging
 // {

--- a/scripts/run-lts-tests.js
+++ b/scripts/run-lts-tests.js
@@ -17,47 +17,47 @@ const distTestDir = join(distDir, 'tests')
  * Fix imports in compiled test files
  */
 function prepareCompiledTests() {
-  console.debug('Preparing compiled test files for LTS...')
+	console.debug('Preparing compiled test files for LTS...')
 
-  // Check if dist/tests directory exists
-  if (!existsSync(distTestDir)) {
-    console.error(`Error: Directory ${distTestDir} not found.`)
-    console.error('Make sure TypeScript compilation completed successfully.')
-    process.exit(1)
-  }
+	// Check if dist/tests directory exists
+	if (!existsSync(distTestDir)) {
+		console.error(`Error: Directory ${distTestDir} not found.`)
+		console.error('Make sure TypeScript compilation completed successfully.')
+		process.exit(1)
+	}
 
-  // Get all compiled test files
-  const testFiles = readdirSync(distTestDir).filter(file => file.endsWith('.test.js'))
+	// Get all compiled test files
+	const testFiles = readdirSync(distTestDir).filter((file) => file.endsWith('.test.js'))
 
-  if (testFiles.length === 0) {
-    console.error('No compiled test files found in the dist/tests directory.')
-    console.error('Make sure TypeScript compilation completed successfully.')
-    process.exit(1)
-  }
+	if (testFiles.length === 0) {
+		console.error('No compiled test files found in the dist/tests directory.')
+		console.error('Make sure TypeScript compilation completed successfully.')
+		process.exit(1)
+	}
 
-  console.debug(`Found ${testFiles.length} compiled test files`)
+	console.debug(`Found ${testFiles.length} compiled test files`)
 
-  // Process each test file to fix imports
-  for (const file of testFiles) {
-    const filePath = join(distTestDir, file)
+	// Process each test file to fix imports
+	for (const file of testFiles) {
+		const filePath = join(distTestDir, file)
 
-    // Read the file
-    let content = readFileSync(filePath, 'utf8')
+		// Read the file
+		let content = readFileSync(filePath, 'utf8')
 
-    // Fix imports - replace .ts extension with .js
-    const originalContent = content
-    content = content.replace(/from ['"]([^'"]+)\.ts['"]\s*;?/g, 'from "$1.js";')
+		// Fix imports - replace .ts extension with .js
+		const originalContent = content
+		content = content.replace(/from ['"]([^'"]+)\.ts['"]\s*;?/g, 'from "$1.js";')
 
-    // Only write if the content changed
-    if (content !== originalContent) {
-      writeFileSync(filePath, content)
-      console.debug(`Fixed imports in ${file}`)
-    } else {
-      console.debug(`No imports to fix in ${file}`)
-    }
-  }
+		// Only write if the content changed
+		if (content !== originalContent) {
+			writeFileSync(filePath, content)
+			console.debug(`Fixed imports in ${file}`)
+		} else {
+			console.debug(`No imports to fix in ${file}`)
+		}
+	}
 
-  console.debug('All compiled test files prepared successfully')
+	console.debug('All compiled test files prepared successfully')
 }
 
 prepareCompiledTests()

--- a/scripts/run-lts-tests.js
+++ b/scripts/run-lts-tests.js
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'

--- a/scripts/run-lts-tests.js
+++ b/scripts/run-lts-tests.js
@@ -1,7 +1,6 @@
-
-import { join, dirname } from 'node:path'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { readdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 
 /**
  * Run tests on compiled JS files for Node.js LTS

--- a/scripts/update-performance-docs.ts
+++ b/scripts/update-performance-docs.ts
@@ -9,9 +9,9 @@
  */
 
 import { execSync } from 'node:child_process'
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { runAllBenchmarks, type BenchmarkResult } from './benchmark.ts'
+import { type BenchmarkResult, runAllBenchmarks } from './benchmark.ts'
 
 // Configuration
 const METRICS_HISTORY_FILE = join(process.cwd(), join('metrics', 'performance-history.json'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export type State<T> = ReadOnlyState<T> &
 /**
  * Creates a reactive state container with the provided initial value.
  */
-export const state = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> => 
+export const state = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> =>
 	StateImpl.createState(initialValue, equalityFn)
 
 /**
@@ -56,7 +56,10 @@ export const readonlyState =
 /**
  * Creates a state with access control, returning a tuple of reader and writer.
  */
-export const protectedState = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): [ReadOnlyState<T>, WriteableState<T>] => {
+export const protectedState = <T>(
+	initialValue: T,
+	equalityFn: (a: T, b: T) => boolean = Object.is
+): [ReadOnlyState<T>, WriteableState<T>] => {
 	const fullState = state(initialValue, equalityFn)
 	return [
 		(): T => readonlyState(fullState)(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ export type State<T> = ReadOnlyState<T> &
 /**
  * Creates a reactive state container with the provided initial value.
  */
-export const state = <T>(initialValue: T): State<T> => StateImpl.createState(initialValue)
+export const state = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> => 
+	StateImpl.createState(initialValue, equalityFn)
 
 /**
  * Registers a function to run whenever its reactive dependencies change.
@@ -55,8 +56,8 @@ export const readonlyState =
 /**
  * Creates a state with access control, returning a tuple of reader and writer.
  */
-export const protectedState = <T>(initialValue: T): [ReadOnlyState<T>, WriteableState<T>] => {
-	const fullState = state(initialValue)
+export const protectedState = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): [ReadOnlyState<T>, WriteableState<T>] => {
+	const fullState = state(initialValue, equalityFn)
 	return [
 		(): T => readonlyState(fullState)(),
 		{
@@ -93,17 +94,19 @@ class StateImpl<T> {
 	private value: T
 	private subscribers = new Set<Subscriber>()
 	private stateId = Symbol()
+	private equalityFn: (a: T, b: T) => boolean
 
-	constructor(initialValue: T) {
+	constructor(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is) {
 		this.value = initialValue
+		this.equalityFn = equalityFn
 	}
 
 	/**
 	 * Creates a reactive state container with the provided initial value.
 	 * Implementation of the public 'state' function.
 	 */
-	static createState = <T>(initialValue: T): State<T> => {
-		const instance = new StateImpl<T>(initialValue)
+	static createState = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> => {
+		const instance = new StateImpl<T>(initialValue, equalityFn)
 		const get = (): T => instance.get()
 		get.set = (value: T): void => instance.set(value)
 		get.update = (fn: (currentValue: T) => T): void => instance.update(fn)
@@ -143,7 +146,7 @@ class StateImpl<T> {
 	// Handles value updates with built-in optimizations and safeguards
 	set = (newValue: T): void => {
 		// Skip updates for unchanged values to prevent redundant effect executions
-		if (Object.is(this.value, newValue)) {
+		if (this.equalityFn(this.value, newValue)) {
 			return
 		}
 

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect, batch } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { batch, effect, state } from '../src/index.ts'
 
 /**
  * Unit tests for the batch functionality.

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect, derive, batch } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { batch, derive, effect, state } from '../src/index.ts'
 
 /**
  * Tests for cleanup/unsubscribe behavior.

--- a/tests/custom-equality.test.ts
+++ b/tests/custom-equality.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { effect, state } from '../src/index.ts'
+
+/**
+ * Unit tests for the state with custom equality function.
+ *
+ * This file tests the custom equality function feature by demonstrating:
+ * - Default behavior with Object.is
+ * - Custom equality function that always returns false (always triggers updates)
+ * - Custom equality function for specific use cases (like logging)
+ */
+describe('Equality', { concurrency: true, timeout: 1000 }, (): void => {
+	// Default behavior (Object.is)
+	it('should use Object.is by default for equality checking', (): void => {
+		const count = state(0)
+		let effectCallCount = 0
+
+		const unsubscribe = effect(() => {
+			count() // Subscribe to count
+			effectCallCount++
+		})
+
+		assert.strictEqual(effectCallCount, 1, 'Effect should run once initially')
+
+		// Set to same value - should not trigger effect
+		count.set(0)
+		assert.strictEqual(effectCallCount, 1, 'Effect should not run when setting same value')
+
+		// Set to different value - should trigger effect
+		count.set(1)
+		assert.strictEqual(effectCallCount, 2, 'Effect should run when value changes')
+
+		unsubscribe()
+	})
+
+	// Custom equality function that always reports differences
+	it('should always update when using custom equality function that returns false', (): void => {
+		// Create state with equality function that always returns false
+		const alwaysUpdateLog = state('First log', () => false)
+		let effectCallCount = 0
+
+		const unsubscribe = effect(() => {
+			alwaysUpdateLog() // Subscribe to log
+			effectCallCount++
+		})
+
+		assert.strictEqual(effectCallCount, 1, 'Effect should run once initially')
+
+		// Set to same value - should still trigger effect with our custom equality function
+		alwaysUpdateLog.set('First log')
+		assert.strictEqual(effectCallCount, 2, 'Effect should run even when setting same value')
+
+		// Set to same value again - should trigger effect again
+		alwaysUpdateLog.set('First log')
+		assert.strictEqual(effectCallCount, 3, 'Effect should run again when setting same value')
+
+		unsubscribe()
+	})
+
+	// Logging use case demonstration
+	it('should support logging use case with reference equality check', (): void => {
+		// Create a log state that uses reference equality instead of value equality
+		const logState = state<string[]>([], (prev, next) => prev === next) // Reference equality
+		let effectCallCount = 0
+
+		const unsubscribe = effect(() => {
+			logState() // Subscribe to logs
+			effectCallCount++
+		})
+
+		assert.strictEqual(effectCallCount, 1, 'Effect should run once initially')
+
+		// Add identical log messages but as new array references
+		logState.set(['System started'])
+		assert.strictEqual(effectCallCount, 2, 'Effect should run with new array reference')
+
+		// Add same message content but as new array reference
+		logState.set(['System started'])
+		assert.strictEqual(effectCallCount, 3, 'Effect should run again with another new reference')
+
+		// Demonstrate value equality wouldn't have worked for this use case
+		const valueEqualityLog = state<string[]>([])
+		let valueEffectCallCount = 0
+
+		const valueUnsubscribe = effect(() => {
+			valueEqualityLog() // Subscribe to logs
+			valueEffectCallCount++
+		})
+
+		valueEqualityLog.set([])
+		assert.strictEqual(valueEffectCallCount, 2, 'First empty array change triggers effect')
+
+		// This update might not trigger the effect if arrays with same content are considered equal
+		// The behavior depends on how deep the equality check goes (Object.is is shallow)
+		valueEqualityLog.set([])
+		assert.strictEqual(valueEffectCallCount, 3, 'Second empty array should trigger with Object.is')
+
+		unsubscribe()
+		valueUnsubscribe()
+	})
+
+	// Custom deep equality function
+	it('should support deep equality comparisons', (): void => {
+		// Simplified equality function specific to our test case
+		// This avoids the complexity warning while still testing the functionality
+		const deepEqual = (a: unknown, b: unknown): boolean => {
+			// For this test we only need to compare { name: string, details: { age: number } }
+			if (a === b) {
+				return true
+			}
+			
+			// If either is not an object, use simple comparison
+			if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+				return a === b
+			}
+			
+			// Safely cast to unknown record types
+			const objA = a as Record<string, unknown>
+			const objB = b as Record<string, unknown>
+			
+			// Check name property
+			if (objA.name !== objB.name) {
+				return false
+			}
+			
+			// Check details - we know the specific structure for this test
+			if (typeof objA.details === 'object' && objA.details !== null && 
+			    typeof objB.details === 'object' && objB.details !== null) {
+				const detailsA = objA.details as Record<string, unknown>
+				const detailsB = objB.details as Record<string, unknown>
+				return detailsA.age === detailsB.age
+			}
+			
+			return false
+		}
+
+		// Create state with deep equality
+		const userData = state({ name: 'Alice', details: { age: 30 } }, deepEqual)
+		let effectCallCount = 0
+
+		const unsubscribe = effect((): void => {
+			userData() // Subscribe to userData
+			effectCallCount++
+		})
+
+		assert.strictEqual(effectCallCount, 1, 'Effect should run once initially')
+
+		// Set to structurally identical but different reference - should not trigger with deep equality
+		userData.set({ name: 'Alice', details: { age: 30 } })
+		assert.strictEqual(effectCallCount, 1, 'Effect should not run when setting structurally identical object')
+
+		// Set to different value - should trigger effect
+		userData.set({ name: 'Alice', details: { age: 31 } })
+		assert.strictEqual(effectCallCount, 2, 'Effect should run when value changes')
+
+		unsubscribe()
+	})
+})

--- a/tests/custom-equality.test.ts
+++ b/tests/custom-equality.test.ts
@@ -109,29 +109,33 @@ describe('Equality', { concurrency: true, timeout: 1000 }, (): void => {
 			if (a === b) {
 				return true
 			}
-			
+
 			// If either is not an object, use simple comparison
 			if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
 				return a === b
 			}
-			
+
 			// Safely cast to unknown record types
 			const objA = a as Record<string, unknown>
 			const objB = b as Record<string, unknown>
-			
+
 			// Check name property
 			if (objA.name !== objB.name) {
 				return false
 			}
-			
+
 			// Check details - we know the specific structure for this test
-			if (typeof objA.details === 'object' && objA.details !== null && 
-			    typeof objB.details === 'object' && objB.details !== null) {
+			if (
+				typeof objA.details === 'object' &&
+				objA.details !== null &&
+				typeof objB.details === 'object' &&
+				objB.details !== null
+			) {
 				const detailsA = objA.details as Record<string, unknown>
 				const detailsB = objB.details as Record<string, unknown>
 				return detailsA.age === detailsB.age
 			}
-			
+
 			return false
 		}
 

--- a/tests/cyclic-dependency.test.ts
+++ b/tests/cyclic-dependency.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect, derive, batch, type State } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { type State, batch, derive, effect, state } from '../src/index.ts'
 
 /**
  * Tests for cyclical dependencies between states.

--- a/tests/deep-chain.test.ts
+++ b/tests/deep-chain.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, derive, batch, type State, type ReadOnlyState } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { type ReadOnlyState, type State, batch, derive, state } from '../src/index.ts'
 
 /**
  * Integration tests for deep dependency chains.

--- a/tests/derive.test.ts
+++ b/tests/derive.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, derive, batch, effect } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { batch, derive, effect, state } from '../src/index.ts'
 
 describe('Derive', { concurrency: true, timeout: 1000 }, (): void => {
 	it('should compute derived value', (): void => {

--- a/tests/effect.test.ts
+++ b/tests/effect.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { effect, state } from '../src/index.ts'
 
 /**
  * Unit tests for the effect functionality.

--- a/tests/infinite-loop.test.ts
+++ b/tests/infinite-loop.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect, derive, batch } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { batch, derive, effect, state } from '../src/index.ts'
 
 /**
  * Tests for infinite loop detection in reactive effects.

--- a/tests/lens.test.ts
+++ b/tests/lens.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect, batch, lens, type State } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { type State, batch, effect, lens, state } from '../src/index.ts'
 
 // Common type definitions
 type User = {

--- a/tests/protected-state.test.ts
+++ b/tests/protected-state.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { protectedState, effect } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { effect, protectedState } from '../src/index.ts'
 
 /**
  * Unit tests for protected state function.

--- a/tests/readonly-state.test.ts
+++ b/tests/readonly-state.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, readonlyState, effect } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { effect, readonlyState, state } from '../src/index.ts'
 
 /**
  * Unit tests for readonly state function.

--- a/tests/select.test.ts
+++ b/tests/select.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { state, effect, batch, select } from '../src/index.ts'
+import { describe, it } from 'node:test'
+import { batch, effect, select, state } from '../src/index.ts'
 
 type LargeState = {
 	criticalValue: string

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
 import { state } from '../src/index.ts'
 
 /**


### PR DESCRIPTION
This feature allows defining when state values should be considered equal, controlling when subscribers are notified of changes.

- Added optional `equalityFn` parameter to `state` and `protectedState`
- Updated internal state implementation to use custom equality checks
- Added comprehensive tests for custom equality functionality
- Added version compatibility table to documentation
- Updated Node (for development) and npm versions