### PR TITLE
chore: update tooling and enforce consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,14 @@
-* text=auto
-*.md text diff=markdown
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
+# Explicitly declare text files
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf diff=markdown
+*.yaml text eol=lf
+*.toml text eol=lf
+
 .gitattributes text linguist-language=gitattributes exports-ignore
 .gitignore text exports-ignore
+
 *.png binary

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
 	"assist": {
 		"actions": {
 			"source": {
@@ -50,8 +50,8 @@
 			"trailingCommas": "none"
 		},
 		"parser": {
-			"allowComments": true,
-			"allowTrailingCommas": true
+			"allowComments": false,
+			"allowTrailingCommas": false
 		}
 	},
 	"linter": {

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "24.10.0"
+node = "24.13.0"
 
 [env]
 NODE_COMPILER_CACHE = "$TMPDIR/.node-cache"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "1000.2.3",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "2.2.7",
-				"@types/node": "24.9.1",
-				"npm-check-updates": "19.1.1",
+				"@biomejs/biome": "2.3.13",
+				"@types/node": "25.0.10",
+				"npm-check-updates": "19.3.2",
 				"typescript": "5.9.3",
 				"uglify-js": "3.19.3"
 			},
@@ -20,9 +20,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.7.tgz",
-			"integrity": "sha512-1a8j0UP1vXVUf3UzMZEJ/zS2VgAG6wU6Cuh/I764sUGI+MCnJs/9WaojHYBDCxCMLTgU60/WqnYof85emXmSBA==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+			"integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -36,20 +36,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.2.7",
-				"@biomejs/cli-darwin-x64": "2.2.7",
-				"@biomejs/cli-linux-arm64": "2.2.7",
-				"@biomejs/cli-linux-arm64-musl": "2.2.7",
-				"@biomejs/cli-linux-x64": "2.2.7",
-				"@biomejs/cli-linux-x64-musl": "2.2.7",
-				"@biomejs/cli-win32-arm64": "2.2.7",
-				"@biomejs/cli-win32-x64": "2.2.7"
+				"@biomejs/cli-darwin-arm64": "2.3.13",
+				"@biomejs/cli-darwin-x64": "2.3.13",
+				"@biomejs/cli-linux-arm64": "2.3.13",
+				"@biomejs/cli-linux-arm64-musl": "2.3.13",
+				"@biomejs/cli-linux-x64": "2.3.13",
+				"@biomejs/cli-linux-x64-musl": "2.3.13",
+				"@biomejs/cli-win32-arm64": "2.3.13",
+				"@biomejs/cli-win32-x64": "2.3.13"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.7.tgz",
-			"integrity": "sha512-xBUUsebnO2/Qj1v7eZmKUy2ZcFkZ4/jLUkxN02Qup1RPoRaiW9AKXHrqS3L7iX6PzofHY2xuZ+Pb9kAcpoe0qA==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+			"integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -64,9 +64,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.7.tgz",
-			"integrity": "sha512-vsY4NhmxqgfLJufr9XUnC+yGUPJiXAc1mz6FcjaAmuIuLwfghN4uQO7hnW2AneGyoi2mNe9Jbvf6Qtq4AjzrFg==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+			"integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
 			"cpu": [
 				"x64"
 			],
@@ -81,9 +81,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.7.tgz",
-			"integrity": "sha512-nUdco104rjV9dULi1VssQ5R/kX2jE/Z2sDjyqS+siV9sTQda0DwmEUixFNRCWvZJRRiZUWhgiDFJ4n7RowO8Mg==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+			"integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -98,9 +98,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.7.tgz",
-			"integrity": "sha512-FrTwvKO/7t5HbVTvhlMOTOVQLAcR7r4O4iFQhEpZXUtBfosHqrX/JJlX7daPawoe14MDcCu9CDg0zLVpTuDvuQ==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+			"integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -115,9 +115,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.7.tgz",
-			"integrity": "sha512-tPTcGAIEOOZrj2tQ7fdraWlaxNKApBw6l4In8wQQV1IyxnAexqi0hykHzKEX8hKKctf5gxGBfNCzyIvqpj4CFQ==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+			"integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
 			"cpu": [
 				"x64"
 			],
@@ -132,9 +132,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.7.tgz",
-			"integrity": "sha512-MnsysF5s/iLC5wnYvuMseOy+m8Pd4bWG1uwlVyy2AUbfjAVUgtbYbboc5wMXljFrDY7e6rLjLTR4S2xqDpGlQg==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+			"integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
 			"cpu": [
 				"x64"
 			],
@@ -149,9 +149,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.7.tgz",
-			"integrity": "sha512-h5D1jhwA2b7cFXerYiJfXHSzzAMFFoEDL5Mc2BgiaEw0iaSgSso/3Nc6FbOR55aTQISql+IpB4PS7JoV26Gdbw==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+			"integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
 			"cpu": [
 				"arm64"
 			],
@@ -166,9 +166,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.7.tgz",
-			"integrity": "sha512-URqAJi0kONyBKG4V9NVafHLDtm6IHmF4qPYi/b6x7MD6jxpWeJiTCO6R5+xDlWckX2T/OGv6Yq3nkz6s0M8Ykw==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+			"integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
 			"cpu": [
 				"x64"
 			],
@@ -183,9 +183,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
-			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+			"version": "25.0.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+			"integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -193,9 +193,9 @@
 			}
 		},
 		"node_modules/npm-check-updates": {
-			"version": "19.1.1",
-			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.1.1.tgz",
-			"integrity": "sha512-vy/uNbaK6Xfj/QzM8OXeALZak67E0uHjUlbdT1YGy4bdj0xlBU6AVd+8bscY8vlDpyzL6Y7mxcrX8kzEDeEpNg==",
+			"version": "19.3.2",
+			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.3.2.tgz",
+			"integrity": "sha512-9rr3z7znFjCSuaFxHGTFR2ZBOvLWaJcpLKmIquoTbDBNrwAGiHhv4MZyty6EJ9Xo/aMn35+2ISPSMgWIXx5Xkg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
 	"author": "Denny Trebbin (nerdalytics)",
 	"description": "A lightweight reactive state library for Node.js backends. Enables reactive state management with automatic dependency tracking and efficient updates for server-side applications.",
 	"devDependencies": {
-		"@biomejs/biome": "2.2.7",
-		"@types/node": "24.9.1",
-		"npm-check-updates": "19.1.1",
+		"@biomejs/biome": "2.3.13",
+		"@types/node": "25.0.10",
+		"npm-check-updates": "19.3.2",
 		"typescript": "5.9.3",
 		"uglify-js": "3.19.3"
 	},
@@ -50,7 +50,7 @@
 	"license": "MIT",
 	"main": "dist/src/index.min.js",
 	"name": "@nerdalytics/beacon",
-	"packageManager": "npm@11.6.2",
+	"packageManager": "npm@11.8.0",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/nerdalytics/beacon.git"


### PR DESCRIPTION
## Summary

- Enforce LF line endings for all text files in .gitattributes
- Update Node.js to 24.13.0
- Update biome to 2.3.13 with stricter JSON parsing
- Update devDependencies (@types/node, npm-check-updates)
- Update npm to 11.8.0