### PR TITLE
Pin GitHub Actions to SHA and add weekly version checker

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -17,12 +17,12 @@ jobs:
     needs: warm-cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24.x
       - id: cache-dependencies
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: node_modules
           key: ${{ runner.os }}-node-24.x-${{ hashFiles('**/package-lock.json') }}
@@ -30,7 +30,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: exit 1
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2.6.0
+        uses: biomejs/setup-biome@b2d22cfd9a11c0950398a316e08e17cf3891e85c # v2.7.0
         with:
           version: latest
       - name: Check linting & code formatting
@@ -38,7 +38,7 @@ jobs:
       - name: Build project
         run: 'npm run build:lts'
       - name: Upload dist directory
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: dist
           path: dist/
@@ -50,12 +50,12 @@ jobs:
           - 20.x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '${{ matrix.node-version }}'
       - id: cache-dependencies
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: node_modules
           key: >-
@@ -67,7 +67,7 @@ jobs:
           echo "Cache miss! Update cached dependencies required.
           exit 1
       - name: Download dist directory
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: dist
           path: dist/
@@ -90,12 +90,12 @@ jobs:
           - 22.x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '${{ matrix.node-version }}'
       - id: cache-dependencies
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: node_modules
           key: >-
@@ -107,7 +107,7 @@ jobs:
           echo "Cache miss! Update cached dependencies required.
           exit 1
       - name: Download dist directory
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: dist
           path: dist/
@@ -129,13 +129,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org/'
       - id: cache-dependencies
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: node_modules
           key: ${{ runner.os }}-node-24.x-${{ hashFiles('**/package-lock.json') }}
@@ -145,7 +145,7 @@ jobs:
           echo "Cache miss! Update cached dependencies required.
           exit 1
       - name: Download dist directory
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: dist
           path: dist/

--- a/.github/workflows/check-action-versions.yml
+++ b/.github/workflows/check-action-versions.yml
@@ -1,0 +1,187 @@
+name: Check Action Versions
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Check for outdated actions
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          declare -A ACTIONS_CURRENT
+          declare -A ACTIONS_LATEST
+          declare -A ACTIONS_SHA
+          OUTDATED_COUNT=0
+
+          echo "Scanning workflow files for GitHub Actions..."
+
+          for workflow in .github/workflows/*.yml; do
+            while IFS= read -r line; do
+              if [[ "$line" =~ uses:[[:space:]]*([^@]+)@([^[:space:]#]+) ]]; then
+                action="${BASH_REMATCH[1]}"
+                version="${BASH_REMATCH[2]}"
+
+                # Skip local actions and reusable workflows
+                if [[ "$action" == ./* ]] || [[ "$action" == .github/* ]]; then
+                  continue
+                fi
+
+                # Store current version (first occurrence wins)
+                if [[ -z "${ACTIONS_CURRENT[$action]:-}" ]]; then
+                  ACTIONS_CURRENT[$action]="$version"
+                fi
+              fi
+            done < "$workflow"
+          done
+
+          echo "Found ${#ACTIONS_CURRENT[@]} unique actions"
+
+          # Check each action for updates
+          for action in "${!ACTIONS_CURRENT[@]}"; do
+            current="${ACTIONS_CURRENT[$action]}"
+            echo "Checking $action (current: $current)..."
+
+            # Get latest release
+            latest=$(gh api "repos/$action/releases/latest" --jq '.tag_name' 2>/dev/null || echo "")
+
+            if [[ -z "$latest" ]]; then
+              # Try getting latest tag if no releases
+              latest=$(gh api "repos/$action/tags" --jq '.[0].name' 2>/dev/null || echo "")
+            fi
+
+            if [[ -z "$latest" ]]; then
+              echo "  Warning: Could not fetch latest version for $action"
+              continue
+            fi
+
+            ACTIONS_LATEST[$action]="$latest"
+
+            # Normalize versions for comparison (strip leading 'v' and SHA)
+            current_normalized="${current#v}"
+            latest_normalized="${latest#v}"
+
+            # Check if current is a SHA (40 hex chars)
+            if [[ "$current" =~ ^[a-f0-9]{40}$ ]]; then
+              # Already pinned to SHA, check comment for version
+              echo "  Already SHA-pinned, skipping comparison"
+              continue
+            fi
+
+            if [[ "$current_normalized" != "$latest_normalized" ]]; then
+              echo "  Outdated: $current -> $latest"
+
+              # Get commit SHA for latest tag
+              sha=$(gh api "repos/$action/git/ref/tags/$latest" --jq '.object.sha' 2>/dev/null || echo "")
+
+              # Handle annotated tags (need to dereference)
+              if [[ -n "$sha" ]]; then
+                obj_type=$(gh api "repos/$action/git/tags/$sha" --jq '.object.type' 2>/dev/null || echo "")
+                if [[ "$obj_type" == "commit" ]]; then
+                  sha=$(gh api "repos/$action/git/tags/$sha" --jq '.object.sha' 2>/dev/null || echo "$sha")
+                fi
+              fi
+
+              if [[ -n "$sha" ]]; then
+                ACTIONS_SHA[$action]="$sha"
+                ((OUTDATED_COUNT++))
+              else
+                echo "  Warning: Could not fetch SHA for $action@$latest"
+              fi
+            else
+              echo "  Up to date"
+            fi
+
+            # Rate limit protection
+            sleep 0.5
+          done
+
+          echo "has_outdated=$( [[ $OUTDATED_COUNT -gt 0 ]] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
+
+          if [[ $OUTDATED_COUNT -gt 0 ]]; then
+            echo "Generating report for $OUTDATED_COUNT outdated actions..."
+
+            cat > outdated-actions-report.md << 'HEADER'
+          ## Outdated GitHub Actions Detected
+
+          The following actions have newer versions available:
+
+          | Action | Current | Latest | Recommended Update |
+          |--------|---------|--------|-------------------|
+          HEADER
+
+            for action in "${!ACTIONS_SHA[@]}"; do
+              current="${ACTIONS_CURRENT[$action]}"
+              latest="${ACTIONS_LATEST[$action]}"
+              sha="${ACTIONS_SHA[$action]}"
+              echo "| \`$action\` | $current | $latest | \`$action@$sha # $latest\` |" >> outdated-actions-report.md
+            done
+
+            cat >> outdated-actions-report.md << 'FOOTER'
+
+          ### How to Update
+
+          Replace each action reference in your workflow files with the SHA-pinned version shown in the "Recommended Update" column.
+
+          ### Why SHA Pinning?
+
+          Pinning to a commit SHA prevents supply chain attacks where a malicious actor could move a tag to point to compromised code. This is the most secure way to reference GitHub Actions.
+
+          ---
+          *This issue was automatically generated by the [Check Action Versions](.github/workflows/check-action-versions.yml) workflow.*
+          FOOTER
+
+            echo "Report generated:"
+            cat outdated-actions-report.md
+          else
+            echo "All actions are up to date!"
+          fi
+
+      - name: Create or update security issue
+        if: steps.check.outputs.has_outdated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ISSUE_TITLE="Security: Outdated GitHub Actions detected"
+
+          EXISTING_ISSUE=$(gh issue list --state open --search "in:title $ISSUE_TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [[ -n "$EXISTING_ISSUE" ]]; then
+            gh issue edit "$EXISTING_ISSUE" --body-file outdated-actions-report.md
+            echo "Updated issue #$EXISTING_ISSUE"
+          else
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --label "security,dependencies" \
+              --body-file outdated-actions-report.md
+            echo "Created new issue"
+          fi
+
+      - name: Close issue if all actions up to date
+        if: steps.check.outputs.has_outdated == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ISSUE_TITLE="Security: Outdated GitHub Actions detected"
+          EXISTING_ISSUE=$(gh issue list --state open --search "in:title $ISSUE_TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [[ -n "$EXISTING_ISSUE" ]]; then
+            gh issue close "$EXISTING_ISSUE" --comment "All GitHub Actions are now up to date."
+            echo "Closed issue #$EXISTING_ISSUE"
+          else
+            echo "No existing issue to close"
+          fi

--- a/.github/workflows/update-dependencies-cache.yml
+++ b/.github/workflows/update-dependencies-cache.yml
@@ -17,14 +17,14 @@ jobs:
           - 24.x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-node@v6.0.0
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ matrix.node-version }}
       - id: cache-dependencies
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: node_modules
           key: >-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![license:mit](https://flat.badgen.net/static/license/MIT/blue)](https://github.com/nerdalytics/beacon/blob/trunk/LICENSE)
 [![registry:npm:version](https://img.shields.io/npm/v/@nerdalytics/beacon.svg)](https://www.npmjs.com/package/@nerdalytics/beacon)
-[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.2.4)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.2.4)
+[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.2.5)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.2.5)
 
 [![tech:nodejs](https://img.shields.io/badge/Node%20js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![language:typescript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://typescriptlang.org/)


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to commit SHAs to prevent supply chain attacks (addresses CodeQL alert #6)
- Add weekly workflow to automatically detect outdated actions and create security issues
- Update Socket.dev badge version

## Changes

### Action Updates
| Action | Previous | Updated |
|--------|----------|---------|
| `actions/checkout` | v5.0.0 | v6.0.1 (SHA-pinned) |
| `actions/setup-node` | v6.0.0 | v6.2.0 (SHA-pinned) |
| `actions/cache` | v4.3.0 | v5.0.2 (SHA-pinned) |
| `biomejs/setup-biome` | v2.6.0 | v2.7.0 (SHA-pinned) |
| `actions/upload-artifact` | v4.6.2 | v6.0.0 (SHA-pinned) |
| `actions/download-artifact` | v5.0.0 | v7.0.0 (SHA-pinned) |

### New Workflow: `check-action-versions.yml`
- Runs weekly (Monday 9:00 UTC) or manually via workflow_dispatch
- Scans all workflow files for GitHub Actions
- Compares current versions against latest releases
- Creates/updates a security issue with SHA-pinned upgrade recommendations
- Auto-closes the issue when all actions are current

## Test plan

- [ ] Verify workflows pass CI
- [ ] Manually trigger the new `Check Action Versions` workflow
- [ ] Confirm issue creation/update behavior works as expected