### PR TITLE
Fix action version checker regex self-matching

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@
 
 [![license:mit](https://flat.badgen.net/static/license/MIT/blue)](https://github.com/nerdalytics/beacon/blob/trunk/LICENSE)
 [![registry:npm:version](https://img.shields.io/npm/v/@nerdalytics/beacon.svg)](https://www.npmjs.com/package/@nerdalytics/beacon)
-[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.2.4)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.2.4)
+[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.2.5)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.2.5)
 
 [![tech:nodejs](https://img.shields.io/badge/Node%20js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![language:typescript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://typescriptlang.org/)

--- a/.github/workflows/check-action-versions.yml
+++ b/.github/workflows/check-action-versions.yml
@@ -39,6 +39,11 @@ jobs:
                   continue
                 fi
 
+                # Validate action format: must be owner/repo (exactly one slash, no special chars)
+                if [[ ! "$action" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$ ]]; then
+                  continue
+                fi
+
                 # Store current version (first occurrence wins)
                 if [[ -z "${ACTIONS_CURRENT[$action]:-}" ]]; then
                   ACTIONS_CURRENT[$action]="$version"


### PR DESCRIPTION
## Summary

Fixes a bug where the workflow was matching its own regex pattern as an action name when scanning itself, causing 404 errors.

## Problem

The regex `uses:[[:space:]]*([^@]+)@([^[:space:]#]+)` was capturing parts of its own pattern from the workflow file, resulting in invalid "action" names being checked against the GitHub API.

## Solution

Added validation to ensure the captured action name matches the expected `owner/repo` format before processing.

## Test plan

- [ ] Re-run the Check Action Versions workflow manually
- [ ] Verify no more 404 errors in the output
- [ ] Confirm it reports 6 unique actions (not 7)