### PR TITLE
Fix action checker: arithmetic exit code and missing labels

### DIFF
--- a/.github/workflows/check-action-versions.yml
+++ b/.github/workflows/check-action-versions.yml
@@ -101,7 +101,7 @@ jobs:
 
               if [[ -n "$sha" ]]; then
                 ACTIONS_SHA[$action]="$sha"
-                ((OUTDATED_COUNT++))
+                ((OUTDATED_COUNT++)) || true
               else
                 echo "  Warning: Could not fetch SHA for $action@$latest"
               fi
@@ -161,6 +161,10 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           ISSUE_TITLE="Security: Outdated GitHub Actions detected"
+
+          # Ensure required labels exist
+          gh label create "security" --description "Security-related issues" --color "D93F0B" --force 2>/dev/null || true
+          gh label create "dependencies" --description "Dependency updates" --color "0366D6" --force 2>/dev/null || true
 
           EXISTING_ISSUE=$(gh issue list --state open --search "in:title $ISSUE_TITLE" --json number --jq '.[0].number' 2>/dev/null || echo "")
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the action version checker workflow.

## Bug 1: Arithmetic exit code

With `set -e`, `((OUTDATED_COUNT++))` exits with code 1 when `OUTDATED_COUNT` is 0 because the expression evaluates to 0 (false).

**Fix**: Added `|| true` to prevent script termination.

## Bug 2: Missing labels

The workflow failed with `could not add label: 'security' not found` when the repository doesn't have the required labels.

**Fix**: Create `security` and `dependencies` labels before creating the issue (using `--force` so it's idempotent).