### PR TITLE
perf(core): add benchmark suite

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@
 
 [![license:mit](https://flat.badgen.net/static/license/MIT/blue)](https://github.com/nerdalytics/beacon/blob/trunk/LICENSE)
 [![registry:npm:version](https://img.shields.io/npm/v/@nerdalytics/beacon.svg)](https://www.npmjs.com/package/@nerdalytics/beacon)
-[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.2.5)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.2.5)
+[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.3.0)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.3.0)
 
 [![tech:nodejs](https://img.shields.io/badge/Node%20js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![language:typescript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://typescriptlang.org/)
@@ -58,6 +58,7 @@ A lightweight reactive state library for Node.js backends. Enables reactive stat
 - **Cycle handling** - Safely manages cyclic dependencies without crashing
 - **Infinite loop detection** - Automatically detects and prevents infinite update loops
 - **TypeScript-first** - Full TypeScript support with generics
+- **Tree-shakeable** - Module-level exports let bundlers eliminate unused code
 - **Lightweight** - Zero dependencies
 - **Node.js compatibility** - Works with Node.js LTS v20+ and v22+
 
@@ -444,9 +445,10 @@ Beacon follows these key principles:
 
 ## Architecture
 
-Beacon is built around a centralized reactivity system with fine-grained dependency tracking. Here's how it works:
+Beacon is built around module-level functions and a closure-based state factory with fine-grained dependency tracking. All exports are independent `const` declarations, so bundlers can tree-shake unused primitives. Here's how it works:
 
 - **Automatic Dependency Collection**: When a state is read inside an effect, Beacon automatically records this dependency
+- **Closure-based State**: Each `state()` call returns a closure over its value and subscriber set
 - **WeakMap-based Tracking**: Uses WeakMaps for automatic garbage collection
 - **Topological Updates**: Updates flow through the dependency graph in the correct order
 - **Memory-Efficient**: Designed for long-running Node.js processes
@@ -531,7 +533,7 @@ app.listen(3000);
 
 #### Can Beacon be used in browser applications?
 
-While Beacon is optimized for Node.js server-side applications, its core principles would work in browser environments. However, the library is specifically designed for backend use cases and hasn't been optimized for browser bundle sizes or DOM integration patterns.
+While Beacon is designed for Node.js server-side applications, it works in browser environments too. The library is fully tree-shakeable (`sideEffects: false`), so bundlers like esbuild, Rollup, and webpack will eliminate any primitives you don't import. It has not been optimized for DOM integration patterns.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![license:mit](https://flat.badgen.net/static/license/MIT/blue)](https://github.com/nerdalytics/beacon/blob/trunk/LICENSE)
 [![registry:npm:version](https://img.shields.io/npm/v/@nerdalytics/beacon.svg)](https://www.npmjs.com/package/@nerdalytics/beacon)
-[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.2.5)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.2.5)
+[![Socket Badge](https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.3.0)](https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.3.0)
 
 [![tech:nodejs](https://img.shields.io/badge/Node%20js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![language:typescript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://typescriptlang.org/)

--- a/TECHNICAL_DETAILS.md
+++ b/TECHNICAL_DETAILS.md
@@ -4,13 +4,15 @@ This document describes the internal implementation details of the Beacon librar
 
 ## Reactive System Architecture
 
-Beacon uses a fine-grained reactivity system with automatic dependency tracking. Here's how the core architecture works:
+Beacon uses a fine-grained reactivity system with automatic dependency tracking. The entire library lives in a single module (`src/index.ts`) as independent `const` function declarations sharing module-level reactive state. This design makes every export tree-shakeable — bundlers can eliminate any primitive a consumer doesn't import.
 
-1. **State Primitives**: Base reactive values that can be read and modified
+Here's how the core architecture works:
+
+1. **State Primitives**: Base reactive values created by a closure factory (`createState`)
 2. **Derived Values**: Computed values that depend on other reactive states
 3. **Effects**: Side effects that run when dependencies change
 4. **Batching**: Optimization for multiple state changes
-5. **Dependency Tracking**: Automatic tracking of dependencies
+5. **Dependency Tracking**: Automatic tracking via module-level WeakMaps
 6. **Selectors**: Targeted subscriptions to subsets of state objects
 
 ### Core API Components
@@ -27,13 +29,15 @@ Beacon's API consists of the following key functions:
 
 ### Dependency Tracking Mechanism
 
+Reactive state is coordinated through 10 module-level variables (5 mutable, 5 WeakMap/Set constants). Each `state()` call returns a closure that captures its own `value`, `subscribers` Set, and `stateId` Symbol, while reading and writing the shared module-level tracking structures.
+
 When an effect or derived state runs:
 
-1. The global `currentSubscriber` variable is set to the current effect
+1. The module-level `currentSubscriber` variable is set to the current effect
 2. Reading any state during execution registers the state as a dependency
 3. A bidirectional relationship is established:
-   - The state keeps track of its subscribers (effects that depend on it)
-   - The effect keeps track of its dependencies (states it depends on)
+   - The state's closure-scoped `subscribers` Set tracks which effects depend on it
+   - The module-level `subscriberDependencies` WeakMap tracks which subscriber sets each effect belongs to
 4. When a state changes, it notifies all its subscribers
 
 ## Cyclical Dependencies
@@ -262,11 +266,12 @@ This system ensures there are no memory leaks from lingering effect subscription
 
 Several optimizations make Beacon efficient:
 
-1. Set-based dependency tracking for fast operations
-2. Value equality checks to prevent unnecessary updates
-3. Specialized handling for small subscriber sets
+1. Closure-based state factory — eliminates class instantiation and method dispatch overhead
+2. Set-based dependency tracking for fast operations
+3. Value equality checks to prevent unnecessary updates
 4. Efficient batching to minimize effect executions
 5. WeakMap for subscriber dependencies to allow garbage collection
+6. Module-level `const` exports with `sideEffects: false` — enables tree-shaking of unused primitives
 
 ---
 

--- a/node.config.json
+++ b/node.config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://nodejs.org/dist/v24.10.0/docs/node-config-schema.json",
+	"$schema": "https://nodejs.org/dist/v24.13.0/docs/node-config-schema.json",
 	"nodeOptions": {
 		"test-coverage-branches": 100,
 		"test-coverage-exclude": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nerdalytics/beacon",
-	"version": "1000.2.5",
+	"version": "1000.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nerdalytics/beacon",
-			"version": "1000.2.5",
+			"version": "1000.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.3.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nerdalytics/beacon",
-	"version": "1000.2.3",
+	"version": "1000.2.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nerdalytics/beacon",
-			"version": "1000.2.3",
+			"version": "1000.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.3.13",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"update-dependencies": "npx npm-check-updates --interactive --upgrade --removeRange",
 		"update-performance-docs": "node --experimental-config-file=node.config.json scripts/update-performance-docs.ts"
 	},
+	"sideEffects": false,
 	"type": "module",
 	"types": "dist/src/index.d.ts",
 	"version": "1000.2.5"

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
 	"sideEffects": false,
 	"type": "module",
 	"types": "dist/src/index.d.ts",
-	"version": "1000.2.5"
+	"version": "1000.3.0"
 }

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,966 +1,312 @@
 import { performance } from 'node:perf_hooks'
-import { batch, derive, effect, lens, readonlyState, type State, state } from '../src/index.ts'
+import type { ReadOnlyState, Unsubscribe } from '../src/index.ts'
+import { batch, derive, effect, state } from '../src/index.ts'
 
-// Configuration
-const NumIterations = 5 // Number of measurement iterations
-const NumWarupIterations = 2 // Number of warmup iterations
+const LOOP_LENGTH = 1_000_000
+const ERROR_FREQUENCY = 1000
+const WARMUP_RUNS = 3
+const BENCH_RUNS = 7
 
-/**
- * Represents the results of a benchmark run
- */
-export interface BenchmarkResult {
-	/** Name of the benchmark */
-	name: string
-	/** Median execution time in milliseconds */
-	median: number | undefined
-	/** Minimum execution time in milliseconds */
-	min: number | undefined
-	/** Maximum execution time in milliseconds */
-	max: number | undefined
-	/** Mean execution time in milliseconds */
-	mean: number
-	/** Operations per second (based on median time) */
-	opsPerSec: number
-	/** Number of measurement iterations performed */
-	iterations: number
-	/** Number of operations performed in each run */
-	operationsPerRun: number
+const EFFECT_TRIGGER_WRITES = 50_000
+const MULTI_SOURCE_COUNT = 100
+const MULTI_SOURCE_ITERATIONS = 100
+const DERIVE_CHAIN_DEPTH = 10
+const DERIVE_CHAIN_ITERATIONS = 1_000
+const STATE_CREATION_COUNT = 100_000
+const STATE_READ_COUNT = 1_000_000
+const SINGLE_SUB_WRITES = 100_000
+const MANY_SUB_COUNT = 100
+const MANY_SUB_WRITES = 10_000
+
+type BenchmarkFn = () => number
+
+function classicLoop(): number {
+	const start = performance.now()
+	let errors = 0
+	let processed = 0
+	let totals = 0
+	for (let i = 0; i <= LOOP_LENGTH; i++) {
+		if (i % ERROR_FREQUENCY === 0) {
+			errors++
+		} else {
+			processed++
+		}
+		totals++
+	}
+	if (processed + errors !== totals) throw new Error('mismatch')
+	return performance.now() - start
 }
 
-/**
- * Represents a benchmark definition
- */
-export interface Benchmark {
-	/** Name of the benchmark */
-	name: string
-	/** Number of operations performed in each run */
-	operationsPerRun: number
-	/** Function that executes the benchmark */
-	run: () => void
-	/** Internal property to store effect runs for comparison metrics */
-	_effectRuns?: number
+function stateNoSubscribers(): number {
+	const s = state(0)
+	const start = performance.now()
+	for (let i = 0; i < LOOP_LENGTH; i++) s.update((v: number): number => v + 1)
+	return performance.now() - start
 }
 
-/**
- * Run a benchmark with proper warmup and multiple iterations
- *
- * @param name - Name of the benchmark
- * @param fn - Benchmark function to execute
- * @param operationsPerRun - Number of operations performed in each run
- * @returns Benchmark results with statistics
- */
-export function runBenchmark(name: string, fn: () => void, operationsPerRun: number): BenchmarkResult {
-	console.debug(`\nRunning benchmark: ${name}`)
-
-	// Warmup phase
-	console.debug(`  Warming up (${NumWarupIterations} iterations)...`)
-	for (let i = 0; i < NumWarupIterations; i++) {
-		fn()
-	}
-
-	// Measurement phase
-	console.debug(`  Measuring (${NumIterations} iterations)...`)
-	const timings: number[] = []
-
-	for (let i = 0; i < NumIterations; i++) {
-		const start = performance.now()
-		fn()
-		const end = performance.now()
-		timings.push(end - start)
-	}
-
-	// Calculate statistics
-	timings.sort((a: number, b: number): number => a - b)
-	const min = timings[0]
-	const max = timings[timings.length - 1]
-	const median = timings[Math.floor(timings.length / 2)]
-	const mean = timings.reduce((sum: number, t: number): number => sum + t, 0) / timings.length
-
-	// Calculate operations per second
-	const opsPerSec = operationsPerRun / (median || 1 / 1000)
-
-	// Report results
-	console.debug(`  Results for ${name}:`)
-	console.debug(`    Time: ${median.toFixed(2)}ms (median) [min: ${min.toFixed(2)}ms, max: ${max.toFixed(2)}ms]`)
-	console.debug(`    Throughput: ${Math.floor(opsPerSec).toLocaleString()} ops/sec`)
-
-	return {
-		iterations: NumIterations,
-		max,
-		mean,
-		median,
-		min,
-		name,
-		operationsPerRun,
-		opsPerSec: Math.floor(opsPerSec),
-	}
+function statePlusDeriveNoEffects(): number {
+	const s = state(0)
+	const totals: ReadOnlyState<number> = derive((): number => s() * 2)
+	const start = performance.now()
+	for (let i = 0; i < LOOP_LENGTH; i++) s.update((v: number): number => v + 1)
+	const end = performance.now()
+	if (totals() !== s() * 2) throw new Error('mismatch')
+	return end - start
 }
 
-// Store effect counts for ratio calculation
-const effectCounts = {
-	batched: 0,
-	individual: 0,
+function statePlusDerivePlusEffects(): number {
+	const s = state(0)
+	const d1: Unsubscribe = effect((): void => {
+		s()
+	})
+	const d2: Unsubscribe = effect((): void => {
+		s()
+	})
+	const totals: ReadOnlyState<number> = derive((): number => s() * 2)
+	const start = performance.now()
+	for (let i = 0; i < LOOP_LENGTH; i++) s.update((v: number): number => v + 1)
+	const end = performance.now()
+	if (totals() !== s() * 2) throw new Error('mismatch')
+	d1()
+	d2()
+	return end - start
 }
 
-// Define benchmarks with consistent approaches
-const benchmarks: Benchmark[] = [
-	// ============================================
-	// MICRO-BENCHMARKS: Isolated hot-path operations
-	// ============================================
-
-	// Pure get() without any effect context - measures raw read performance
-	{
-		name: 'Micro: Pure get() (no effect context)',
-		operationsPerRun: 1_000_000,
-		run: (): void => {
-			const counter = state(42)
-			for (let i = 0; i < 1_000_000; i++) {
-				counter()
+function batchPlusDeriveNoEffects(): number {
+	const errors = state(0)
+	const processed = state(0)
+	const totals: ReadOnlyState<number> = derive((): number => errors() + processed())
+	const start = performance.now()
+	batch((): void => {
+		for (let i = 0; i <= LOOP_LENGTH; i++) {
+			if (i % ERROR_FREQUENCY === 0) {
+				errors.update((v: number): number => v + 1)
+			} else {
+				processed.update((v: number): number => v + 1)
 			}
-		},
-	},
+		}
+	})
+	const end = performance.now()
+	if (processed() + errors() !== totals()) throw new Error('mismatch')
+	return end - start
+}
 
-	// Pure set() without any subscribers - measures raw write performance
-	{
-		name: 'Micro: Pure set() (no subscribers)',
-		operationsPerRun: 1_000_000,
-		run: (): void => {
-			const counter = state(0)
-			for (let i = 0; i < 1_000_000; i++) {
-				counter.set(i)
+function batchPlusDerivePlusEffects(): number {
+	const errors = state(0)
+	const processed = state(0)
+	const d1: Unsubscribe = effect((): void => {
+		errors()
+	})
+	const d2: Unsubscribe = effect((): void => {
+		processed()
+	})
+	const totals: ReadOnlyState<number> = derive((): number => errors() + processed())
+	const start = performance.now()
+	batch((): void => {
+		for (let i = 0; i <= LOOP_LENGTH; i++) {
+			if (i % ERROR_FREQUENCY === 0) {
+				errors.update((v: number): number => v + 1)
+			} else {
+				processed.update((v: number): number => v + 1)
 			}
-		},
-	},
-
-	// set() with 1 subscriber - baseline for subscriber overhead
-	{
-		name: 'Micro: set() with 1 subscriber',
-		operationsPerRun: 100_000,
-		run: (): void => {
-			const counter = state(0)
-			const cleanup = effect((): void => {
-				counter()
-			})
-
-			for (let i = 0; i < 100_000; i++) {
-				counter.set(i)
-			}
-
-			cleanup()
-		},
-	},
-
-	// set() with 10 subscribers - measure scaling
-	{
-		name: 'Micro: set() with 10 subscribers',
-		operationsPerRun: 100_000,
-		run: (): void => {
-			const counter = state(0)
-			const cleanups: (() => void)[] = []
-
-			for (let j = 0; j < 10; j++) {
-				cleanups.push(
-					effect((): void => {
-						counter()
-					})
-				)
-			}
-
-			for (let i = 0; i < 100_000; i++) {
-				counter.set(i)
-			}
-
-			for (const cleanup of cleanups) {
-				cleanup()
-			}
-		},
-	},
-
-	// set() with 100 subscribers - measure scaling at higher counts
-	{
-		name: 'Micro: set() with 100 subscribers',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			const counter = state(0)
-			const cleanups: (() => void)[] = []
-
-			for (let j = 0; j < 100; j++) {
-				cleanups.push(
-					effect((): void => {
-						counter()
-					})
-				)
-			}
-
-			for (let i = 0; i < 10_000; i++) {
-				counter.set(i)
-			}
-
-			for (const cleanup of cleanups) {
-				cleanup()
-			}
-		},
-	},
-
-	// WeakMap lookup overhead - baseline for dependency tracking cost
-	{
-		name: 'Micro: WeakMap lookups',
-		operationsPerRun: 1_000_000,
-		run: (): void => {
-			const map = new WeakMap<object, number>()
-			const key = {}
-			map.set(key, 42)
-
-			for (let i = 0; i < 1_000_000; i++) {
-				map.get(key)
-			}
-		},
-	},
-
-	// Set.add/delete overhead - baseline for subscriber management
-	{
-		name: 'Micro: Set add/delete cycle',
-		operationsPerRun: 100_000,
-		run: (): void => {
-			const set = new Set<number>()
-			for (let i = 0; i < 100_000; i++) {
-				set.add(i)
-				set.delete(i)
-			}
-		},
-	},
-
-	// Array.from(Set) vs Set swap - compare notification patterns
-	{
-		name: 'Micro: Array.from(Set) copy',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			const set = new Set<number>()
-			for (let i = 0; i < 100; i++) {
-				set.add(i)
-			}
-
-			for (let i = 0; i < 10_000; i++) {
-				const arr = Array.from(set)
-				for (const item of arr) {
-					// Simulate processing
-					void item
-				}
-			}
-		},
-	},
-
-	// Set swap pattern - alternative to Array.from
-	{
-		name: 'Micro: Set swap pattern',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			let current = new Set<number>()
-			for (let i = 0; i < 100; i++) {
-				current.add(i)
-			}
-
-			for (let i = 0; i < 10_000; i++) {
-				const toProcess = current
-				current = new Set()
-				for (const item of toProcess) {
-					// Simulate processing
-					void item
-				}
-				// Repopulate for next iteration
-				for (let j = 0; j < 100; j++) {
-					current.add(j)
-				}
-			}
-		},
-	},
-
-	// ============================================
-	// STANDARD BENCHMARKS: Base operations on signals
-	// ============================================
-	{
-		name: 'Signal Creation',
-		operationsPerRun: 100_000,
-		run: (): void => {
-			// Just create signals with no derived values or effects
-			for (let i = 0; i < 100_000; i++) {
-				state(i)
-			}
-		},
-	},
-	{
-		name: 'Signal Reading',
-		operationsPerRun: 1_000_000,
-		run: (): void => {
-			// Just read from a state with no derived values or effects
-			const counter = state(0)
-			for (let i = 0; i < 1_000_000; i++) {
-				counter()
-			}
-		},
-	},
-	{
-		name: 'Signal Writing',
-		operationsPerRun: 100_000,
-		run: (): void => {
-			// Write to a state with no derived values or effects
-			const counter = state(0)
-			for (let i = 0; i < 100_000; i++) {
-				counter.set(i)
-			}
-		},
-	},
-
-	// Standard use cases that include downstream updates
-	{
-		name: 'Derived Signals',
-		operationsPerRun: 50_000,
-		run: (): void => {
-			// The derived signal represents a common use case with
-			// a state and a computation based on it
-			const counter = state(0)
-			const doubled = derive((): number => counter() * 2)
-
-			for (let i = 0; i < 50_000; i++) {
-				counter.set(i)
-				doubled() // Read the derived value to verify
-			}
-		},
-	},
-	{
-		name: 'Effect Triggers',
-		operationsPerRun: 50_000,
-		run: (): void => {
-			// This measures the cost of triggering effects
-			// which is a common use case in reactive applications
-			const counter = state(0)
-			let effectRuns = 0
-
-			const cleanup = effect((): void => {
-				counter() // Subscribe to counter
-				effectRuns++
-			})
-
-			// Reset counter after initial effect
-			effectRuns = 0
-
-			// Just run all the updates without any async code
-			for (let i = 0; i < 50_000; i++) {
-				counter.set(i)
-			}
-
-			cleanup()
-
-			console.debug(`  Note: Effect ran ${effectRuns} times out of 50,000 state updates`)
-		},
-	},
-
-	// Comparison benchmarks for batching vs individual updates
-	{
-		name: 'Update 100 States Individually',
-		operationsPerRun: 10_000, // 100 counters × 100 iterations
-		run: (): void => {
-			// Reset effect counter for this benchmark
-			effectCounts.individual = 0
-
-			// This benchmark represents updating multiple related states
-			// without batching, which is a common anti-pattern
-			const NumCounters = 100
-			const NumIterations = 100
-
-			// Create states
-			const counters = Array.from(
-				{
-					length: NumCounters,
-				},
-				(_: unknown, i: number): State<number> => state(i)
-			)
-
-			// Create a variable to add non-determinism
-			// This creates some natural variation in measurement between runs
-			const skips = Math.floor(Math.random() * 3) // 0, 1, or 2
-
-			// Create effect that depends on all states
-			const cleanup = effect((): void => {
-				let _sum = 0
-				for (const counter of counters) {
-					_sum += counter()
-				}
-
-				// Sometimes we might skip incrementing
-				// This produces more realistic variation between runs
-				if (Math.random() > 0.01 * skips) {
-					effectCounts.individual++
-				}
-			})
-
-			// Reset counter after initial effect
-			effectCounts.individual = 0
-
-			// Perform individual updates
-			for (let iteration = 0; iteration < NumIterations; iteration++) {
-				// Update each counter individually
-				for (let i = 0; i < NumCounters; i++) {
-					counters[i].set(i + iteration)
-				}
-			}
-
-			cleanup()
-
-			console.debug(`  Note: Effect ran approximately ${effectCounts.individual} times during individual updates`)
-		},
-	},
-	{
-		name: 'Update 100 States with Batching',
-		operationsPerRun: 10_000, // 100 counters × 100 iterations
-		run: (): void => {
-			// Reset effect counter for this benchmark
-			effectCounts.batched = 0
-
-			// This benchmark is identical to the individual updates
-			// but uses batching, which is the recommended approach
-			const NumCounters = 100
-			const NumIterations = 100
-
-			// Create states (identical to individual benchmark)
-			const counters = Array.from(
-				{
-					length: NumCounters,
-				},
-				(_: unknown, i: number): State<number> => state(i)
-			)
-
-			// Create a variable to add non-determinism
-			// This creates some natural variation in measurement between runs
-			const skips = Math.floor(Math.random() * 2) // 0 or 1
-
-			// Create effect that depends on all states (identical to individual benchmark)
-			const cleanup = effect((): void => {
-				let _sum = 0
-				for (const counter of counters) {
-					_sum += counter()
-				}
-
-				// Sometimes we might skip incrementing
-				// This produces more realistic variation between runs
-				if (Math.random() > 0.01 * skips) {
-					effectCounts.batched++
-				}
-			})
-
-			// Reset counter after initial effect
-			effectCounts.batched = 0
-
-			// Perform batched updates
-			for (let iteration = 0; iteration < NumIterations; iteration++) {
-				batch((): void => {
-					// Update each counter (same operations as individual update)
-					for (let i = 0; i < NumCounters; i++) {
-						counters[i].set(i + iteration)
-					}
-				})
-			}
-
-			cleanup()
-
-			console.debug(`  Note: Effect ran approximately ${effectCounts.batched} times with batching`)
-		},
-	},
-
-	// Complex scenarios
-	{
-		name: 'Deep Dependency Chain',
-		operationsPerRun: 10_000, // 10 signals × 1000 iterations
-		run: (): void => {
-			// This benchmark tests performance with deeply nested derived signals
-			const NumChainDepth = 10
-			const NumIterations = 1000
-
-			// Create a chain of derived signals
-			const source = state(0)
-			let current = readonlyState(source)
-
-			// Create a chain of derived signals
-			for (let i = 1; i < NumChainDepth; i++) {
-				const prev = current
-				current = derive((): number => prev() + 1)
-			}
-
-			// Verify initial values
-			if (current() !== NumChainDepth - 1) {
-				throw new Error(`Initial chain value incorrect: expected ${NumChainDepth - 1}, got ${current()}`)
-			}
-
-			// Track effect count to verify dependency tracking
-			let effectRuns = 0
-			const cleanup = effect((): void => {
-				current() // Subscribe to the end of the chain
-				effectRuns++
-			})
-
-			// Reset counter after initial effect
-			effectRuns = 0
-
-			// Update source multiple times
-			for (let i = 0; i < NumIterations; i++) {
-				source.set(i)
-			}
-
-			// Verify final value
-			const expected = NumIterations - 1 + (NumChainDepth - 1)
-			if (current() !== expected) {
-				throw new Error(`Final chain value incorrect: expected ${expected}, got ${current()}`)
-			}
-
-			cleanup()
-
-			console.debug(`  Note: Effect at depth ${NumChainDepth} ran ${effectRuns} times`)
-		},
-	},
-	{
-		name: 'Many Dependencies',
-		operationsPerRun: 10_000, // 100 signals × 100 iterations
-		run: (): void => {
-			// This benchmark tests performance with many source dependencies
-			const NumSources = 100
-			const NumIterations = 100
-
-			// Create many source signals
-			const sources = Array.from(
-				{
-					length: NumSources,
-				},
-				(_: unknown, i: number): State<number> => state(i)
-			)
-
-			// Create a derived signal that depends on all sources
-			const sum = derive((): number =>
-				sources.reduce((acc: number, source: State<number>): number => acc + source(), 0)
-			)
-
-			// Track effect count
-			let effectRuns = 0
-			const cleanup = effect((): void => {
-				sum() // Access derived value
-				effectRuns++
-			})
-
-			// Reset after initial effect
-			effectRuns = 0
-
-			// Verify initial sum
-			const expectedInitial = (NumSources * (NumSources - 1)) / 2
-			if (sum() !== expectedInitial) {
-				throw new Error(`Initial sum incorrect: expected ${expectedInitial}, got ${sum()}`)
-			}
-
-			// Run iterations with batching to avoid excessive effect runs
-			for (let iter = 0; iter < NumIterations; iter++) {
-				batch((): void => {
-					for (let i = 0; i < NumSources; i++) {
-						sources[i].set(i + iter)
-					}
-				})
-
-				// Verify sum at each step
-				const expectedSum = (NumSources * (NumSources - 1)) / 2 + NumSources * iter
-				if (sum() !== expectedSum) {
-					throw new Error(`Sum incorrect: expected ${expectedSum}, got ${sum()}`)
-				}
-			}
-
-			cleanup()
-
-			console.debug(`  Note: Effect with ${NumSources} dependencies ran ${effectRuns} times`)
-		},
-	},
-
-	// ============================================
-	// LENS BENCHMARKS: Fine-grained reactivity
-	// ============================================
-
-	// Lens creation overhead
-	{
-		name: 'Lens: Creation',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface User {
-				name: string
-				age: number
-			}
-			const userState = state<User>({
-				age: 30,
-				name: 'John',
-			})
-
-			for (let i = 0; i < 10_000; i++) {
-				lens(userState, (u) => u.name)
-			}
-		},
-	},
-
-	// Lens reading performance
-	{
-		name: 'Lens: Reading',
-		operationsPerRun: 100_000,
-		run: (): void => {
-			interface User {
-				name: string
-				age: number
-			}
-			const userState = state<User>({
-				age: 30,
-				name: 'John',
-			})
-			const nameLens = lens(userState, (u) => u.name)
-
-			for (let i = 0; i < 100_000; i++) {
-				nameLens()
-			}
-		},
-	},
-
-	// Lens writing (propagates to source)
-	{
-		name: 'Lens: Writing',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface User {
-				name: string
-				age: number
-			}
-			const userState = state<User>({
-				age: 30,
-				name: 'John',
-			})
-			const nameLens = lens(userState, (u) => u.name)
-
-			for (let i = 0; i < 10_000; i++) {
-				nameLens.set(`Name${i}`)
-			}
-		},
-	},
-
-	// Lens with effect - fine-grained updates
-	{
-		name: 'Lens: Fine-grained Effect Updates',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface User {
-				name: string
-				age: number
-				score: number
-			}
-			const userState = state<User>({
-				age: 30,
-				name: 'John',
-				score: 100,
-			})
-			const nameLens = lens(userState, (u) => u.name)
-			const ageLens = lens(userState, (u) => u.age)
-
-			let nameEffectRuns = 0
-			let ageEffectRuns = 0
-
-			const cleanupName = effect((): void => {
-				nameLens()
-				nameEffectRuns++
-			})
-
-			const cleanupAge = effect((): void => {
-				ageLens()
-				ageEffectRuns++
-			})
-
-			// Reset after initial runs
-			nameEffectRuns = 0
-			ageEffectRuns = 0
-
-			// Update only name - age effect should NOT run
-			for (let i = 0; i < 5_000; i++) {
-				nameLens.set(`Name${i}`)
-			}
-
-			// Update only age - name effect should NOT run
-			for (let i = 0; i < 5_000; i++) {
-				ageLens.set(i)
-			}
-
-			cleanupName()
-			cleanupAge()
-
-			console.debug(`  Note: Name effect ran ${nameEffectRuns} times, Age effect ran ${ageEffectRuns} times`)
-		},
-	},
-
-	// Deep nested lens
-	{
-		name: 'Lens: Deep Nested Path',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface DeepState {
-				level1: {
-					level2: {
-						level3: {
-							value: number
-						}
-					}
-				}
-			}
-			const deepState = state<DeepState>({
-				level1: {
-					level2: {
-						level3: {
-							value: 0,
-						},
-					},
-				},
-			})
-			const deepLens = lens(deepState, (s) => s.level1.level2.level3.value)
-
-			for (let i = 0; i < 10_000; i++) {
-				deepLens.set(i)
-			}
-
-			// Verify final value
-			if (deepLens() !== 9999) {
-				throw new Error(`Deep lens value incorrect: expected 9999, got ${deepLens()}`)
-			}
-		},
-	},
-
-	// Multiple lenses on same source - independence test
-	{
-		name: 'Lens: Multiple Independent Lenses',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface Config {
-				a: number
-				b: number
-				c: number
-				d: number
-				e: number
-			}
-			const configState = state<Config>({
-				a: 0,
-				b: 0,
-				c: 0,
-				d: 0,
-				e: 0,
-			})
-
-			const lensA = lens(configState, (c) => c.a)
-			const lensB = lens(configState, (c) => c.b)
-			const lensC = lens(configState, (c) => c.c)
-			const lensD = lens(configState, (c) => c.d)
-			const lensE = lens(configState, (c) => c.e)
-
-			// Update each lens independently
-			for (let i = 0; i < 2_000; i++) {
-				lensA.set(i)
-				lensB.set(i * 2)
-				lensC.set(i * 3)
-				lensD.set(i * 4)
-				lensE.set(i * 5)
-			}
-		},
-	},
-
-	// Lens vs Direct State comparison - updating nested property
-	{
-		name: 'Lens: vs Direct State.update()',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface User {
-				profile: {
-					name: string
-					settings: {
-						theme: string
-					}
-				}
-			}
-
-			// Using lens
-			const userWithLens = state<User>({
-				profile: {
-					name: 'John',
-					settings: {
-						theme: 'dark',
-					},
-				},
-			})
-			const themeLens = lens(userWithLens, (u) => u.profile.settings.theme)
-
-			for (let i = 0; i < 5_000; i++) {
-				themeLens.set(i % 2 === 0 ? 'dark' : 'light')
-			}
-
-			// Using direct update for comparison
-			const userDirect = state<User>({
-				profile: {
-					name: 'John',
-					settings: {
-						theme: 'dark',
-					},
-				},
-			})
-
-			for (let i = 0; i < 5_000; i++) {
-				userDirect.update((u) => ({
-					...u,
-					profile: {
-						...u.profile,
-						settings: {
-							...u.profile.settings,
-							theme: i % 2 === 0 ? 'dark' : 'light',
-						},
-					},
-				}))
-			}
-		},
-	},
-
-	// Lens array element update
-	{
-		name: 'Lens: Array Element Updates',
-		operationsPerRun: 10_000,
-		run: (): void => {
-			interface ListState {
-				items: number[]
-			}
-			const listState = state<ListState>({
-				items: [
-					1,
-					2,
-					3,
-					4,
-					5,
-					6,
-					7,
-					8,
-					9,
-					10,
-				],
-			})
-
-			// Create lens for middle element
-			const itemLens = lens(listState, (s) => s.items[4])
-
-			for (let i = 0; i < 10_000; i++) {
-				itemLens.set(i)
-			}
-
-			// Verify the array was updated correctly
-			if (listState().items[4] !== 9999) {
-				throw new Error(`Array element incorrect: expected 9999, got ${listState().items[4]}`)
-			}
-		},
-	},
-]
-
-/**
- * Run all benchmarks and collect results
- * @returns Array of benchmark results
- */
-export function runAllBenchmarks(): BenchmarkResult[] {
-	const results: BenchmarkResult[] = []
-
-	for (const benchmark of benchmarks) {
-		const result = runBenchmark(benchmark.name, benchmark.run, benchmark.operationsPerRun)
-		results.push(result)
+		}
+	})
+	const end = performance.now()
+	if (processed() + errors() !== totals()) throw new Error('mismatch')
+	d1()
+	d2()
+	return end - start
+}
+
+function stateCreation(): number {
+	const start = performance.now()
+	for (let i = 0; i < STATE_CREATION_COUNT; i++) {
+		state(i)
 	}
+	return performance.now() - start
+}
 
-	// Calculate performance ratios between batched and unbatched operations
-	const batchedResult = results.find((r: BenchmarkResult): boolean => r.name === 'Update 100 States with Batching')
-	const individualResult = results.find((r: BenchmarkResult): boolean => r.name === 'Update 100 States Individually')
+function stateReadNoEffect(): number {
+	const s = state(42)
+	const start = performance.now()
+	for (let i = 0; i < STATE_READ_COUNT; i++) {
+		s()
+	}
+	return performance.now() - start
+}
 
-	if (batchedResult && individualResult) {
-		// Calculate batch performance ratio (throughput comparison)
-		const batchedOps = batchedResult.opsPerSec
-		const individualOps = individualResult.opsPerSec
-		const performanceRatio = batchedOps / individualOps
+function stateWrite1Sub(): number {
+	const s = state(0)
+	const cleanup: Unsubscribe = effect((): void => {
+		s()
+	})
+	const start = performance.now()
+	for (let i = 0; i < SINGLE_SUB_WRITES; i++) {
+		s.set(i)
+	}
+	const end = performance.now()
+	cleanup()
+	return end - start
+}
 
-		// Get the actual measured effect run counts from our shared object
-		// These will vary slightly between runs due to GC, scheduling, etc.
-		const individualEffectRuns = effectCounts.individual || 9900 // fallback
-		const batchedEffectRuns = effectCounts.batched || 99 // fallback
-
-		// Calculate the actual measured ratio (should be close to 100x)
-		const effectReductionRatio = individualEffectRuns / (batchedEffectRuns || 1)
-
-		console.debug(`  Effect runs comparison: ${individualEffectRuns} individual vs ${batchedEffectRuns} batched`)
-		console.debug(`  Performance ratio: ${performanceRatio.toFixed(2)}x faster operations per second with batching`)
-		console.debug(
-			`  Effect reduction: ${effectReductionRatio.toFixed(2)}x (batching triggers only ${(100 / effectReductionRatio).toFixed(1)}% of the effect runs)`
+function stateWrite100Subs(): number {
+	const s = state(0)
+	const cleanups: Unsubscribe[] = []
+	for (let j = 0; j < MANY_SUB_COUNT; j++) {
+		cleanups.push(
+			effect((): void => {
+				s()
+			})
 		)
-
-		// Add performance ratio to results
-		results.push({
-			iterations: 1,
-			max: performanceRatio,
-			mean: performanceRatio,
-			median: performanceRatio,
-			min: performanceRatio,
-			name: 'Batch Performance Ratio',
-			operationsPerRun: 1,
-			opsPerSec: performanceRatio,
-		})
-
-		// Add effect reduction ratio to results
-		results.push({
-			iterations: 1,
-			max: effectReductionRatio,
-			mean: effectReductionRatio,
-			median: effectReductionRatio,
-			min: effectReductionRatio,
-			name: 'Batch Effect Reduction',
-			operationsPerRun: 1,
-			opsPerSec: effectReductionRatio,
-		})
 	}
+	const start = performance.now()
+	for (let i = 0; i < MANY_SUB_WRITES; i++) {
+		s.set(i)
+	}
+	const end = performance.now()
+	for (const c of cleanups) c()
+	return end - start
+}
 
-	// Output results in console table for readability
-	//
+function effectTriggers(): number {
+	const s = state(0)
+	const cleanup: Unsubscribe = effect((): void => {
+		s()
+	})
+	const start = performance.now()
+	for (let i = 0; i < EFFECT_TRIGGER_WRITES; i++) {
+		s.set(i)
+	}
+	const end = performance.now()
+	cleanup()
+	return end - start
+}
 
-	console.debug('\nBenchmark results summary:')
-	console.table(
-		results.map(
-			(
-				r: BenchmarkResult
-			): {
-				name: string
-				'ops/sec': string
-				'median (ms)': string
-				value: string
-			} => {
-				// For ratio metrics, show the ratio directly instead of ops/sec
-				if (r.name.includes('Ratio') || r.name.includes('Reduction')) {
-					return {
-						'median (ms)': '-',
-						name: r.name,
-						'ops/sec': '-',
-						value: `${r.median.toFixed(2)}x`,
-					}
-				}
-				return {
-					'median (ms)': r.median.toFixed(2),
-					name: r.name,
-					'ops/sec': Math.floor(r.opsPerSec).toLocaleString(),
-					value: '',
-				}
-			}
-		)
+function manyDependencies(): number {
+	const sources = Array.from(
+		{
+			length: MULTI_SOURCE_COUNT,
+		},
+		(_: unknown, i: number) => state(i)
 	)
-
-	return results
-}
-
-// Only run benchmarks if this file is executed directly
-if (import.meta.url === process.argv[1] || import.meta.url.endsWith(process.argv[1].replace('file://', ''))) {
-	try {
-		runAllBenchmarks()
-	} catch (err) {
-		console.error('Benchmark failed:', err)
-		process.exit(1)
+	const sum: ReadOnlyState<number> = derive((): number => {
+		let acc = 0
+		for (const src of sources) acc += src()
+		return acc
+	})
+	const cleanup: Unsubscribe = effect((): void => {
+		sum()
+	})
+	const start = performance.now()
+	for (let iter = 0; iter < MULTI_SOURCE_ITERATIONS; iter++) {
+		batch((): void => {
+			for (let i = 0; i < MULTI_SOURCE_COUNT; i++) {
+				sources[i].set(i + iter)
+			}
+		})
 	}
+	const end = performance.now()
+	cleanup()
+	return end - start
 }
+
+function deriveChainDepth10(): number {
+	const source = state(0)
+	let current: ReadOnlyState<number> = derive((): number => source())
+	for (let i = 1; i < DERIVE_CHAIN_DEPTH; i++) {
+		const prev = current
+		current = derive((): number => prev() + 1)
+	}
+	const cleanup: Unsubscribe = effect((): void => {
+		current()
+	})
+	const start = performance.now()
+	for (let i = 0; i < DERIVE_CHAIN_ITERATIONS; i++) {
+		source.set(i)
+	}
+	const end = performance.now()
+	cleanup()
+	return end - start
+}
+
+function update100StatesIndividual(): number {
+	const counters = Array.from(
+		{
+			length: MULTI_SOURCE_COUNT,
+		},
+		(_: unknown, i: number) => state(i)
+	)
+	const cleanup: Unsubscribe = effect((): void => {
+		let _sum = 0
+		for (const c of counters) _sum += c()
+	})
+	const start = performance.now()
+	for (let iter = 0; iter < MULTI_SOURCE_ITERATIONS; iter++) {
+		for (let i = 0; i < MULTI_SOURCE_COUNT; i++) {
+			counters[i].set(i + iter)
+		}
+	}
+	const end = performance.now()
+	cleanup()
+	return end - start
+}
+
+function update100StatesBatched(): number {
+	const counters = Array.from(
+		{
+			length: MULTI_SOURCE_COUNT,
+		},
+		(_: unknown, i: number) => state(i)
+	)
+	const cleanup: Unsubscribe = effect((): void => {
+		let _sum = 0
+		for (const c of counters) _sum += c()
+	})
+	const start = performance.now()
+	for (let iter = 0; iter < MULTI_SOURCE_ITERATIONS; iter++) {
+		batch((): void => {
+			for (let i = 0; i < MULTI_SOURCE_COUNT; i++) {
+				counters[i].set(i + iter)
+			}
+		})
+	}
+	const end = performance.now()
+	cleanup()
+	return end - start
+}
+
+function runBench(name: string, fn: BenchmarkFn): void {
+	for (let i = 0; i < WARMUP_RUNS; i++) fn()
+	const results: number[] = []
+	for (let i = 0; i < BENCH_RUNS; i++) results.push(fn())
+	results.sort((a: number, b: number): number => a - b)
+	const median = results[Math.floor(results.length / 2)]
+	const min = results[0]
+	const max = results[results.length - 1]
+	const mean = results.reduce((a: number, b: number): number => a + b, 0) / results.length
+	const sd = Math.sqrt(results.reduce((sum: number, v: number): number => sum + (v - mean) ** 2, 0) / results.length)
+	console.info(
+		`${name}:  med=${median.toFixed(2)}ms  min=${min.toFixed(2)}ms  max=${max.toFixed(2)}ms  sd=${sd.toFixed(2)}ms`
+	)
+}
+
+console.info(`=== Beacon v1000 Benchmark (${LOOP_LENGTH.toLocaleString()} iterations) ===`)
+console.info('')
+runBench('classic loop              ', classicLoop)
+runBench('state no subs             ', stateNoSubscribers)
+runBench('state + derive            ', statePlusDeriveNoEffects)
+runBench('state + derive + 2 effects', statePlusDerivePlusEffects)
+runBench('batch + derive            ', batchPlusDeriveNoEffects)
+runBench('batch + derive + 2 effects', batchPlusDerivePlusEffects)
+console.info('')
+console.info('--- Targeted benchmarks ---')
+console.info('')
+runBench('state creation            ', stateCreation)
+runBench('state read (no effect)    ', stateReadNoEffect)
+runBench('state write 1 sub         ', stateWrite1Sub)
+runBench('state write 100 subs      ', stateWrite100Subs)
+runBench('effect triggers           ', effectTriggers)
+runBench('many dependencies         ', manyDependencies)
+runBench('derive chain depth 10     ', deriveChainDepth10)
+runBench('100 states individual     ', update100StatesIndividual)
+runBench('100 states batched        ', update100StatesBatched)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 // Core types for reactive primitives
 type Subscriber = () => void
-export type Unsubscribe = () => void
-export type ReadOnlyState<T> = () => T
-export interface WriteableState<T> {
+type Unsubscribe = () => void
+type ReadOnlyState<T> = () => T
+interface WriteableState<T> {
 	set(value: T): void
 	update(fn: (value: T) => T): void
 }
@@ -10,550 +10,320 @@ export interface WriteableState<T> {
 // Special symbol used for internal tracking
 const STATE_ID: unique symbol = Symbol('STATE_ID')
 
-export type State<T> = ReadOnlyState<T> &
+type State<T> = ReadOnlyState<T> &
 	WriteableState<T> & {
 		[STATE_ID]?: symbol
 	}
 
-/**
- * Creates a reactive state container with the provided initial value.
- */
-export const state = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> =>
-	StateImpl.createState(initialValue, equalityFn)
+// Module-level reactive state
+let currentSubscriber: Subscriber | null = null
+let pendingSubscribers: Set<Subscriber> = new Set<Subscriber>()
+let isNotifying = false
+let batchDepth = 0
+let deferredEffectCreations: Subscriber[] = []
+const activeSubscribers: Set<Subscriber> = new Set<Subscriber>()
+const stateTracking: WeakMap<Subscriber, Set<symbol>> = new WeakMap<Subscriber, Set<symbol>>()
+const subscriberDependencies: WeakMap<Subscriber, Set<Set<Subscriber>>> = new WeakMap<
+	Subscriber,
+	Set<Set<Subscriber>>
+>()
+const parentSubscriber: WeakMap<Subscriber, Subscriber> = new WeakMap<Subscriber, Subscriber>()
+const childSubscribers: WeakMap<Subscriber, Set<Subscriber>> = new WeakMap<Subscriber, Set<Subscriber>>()
 
-/**
- * Registers a function to run whenever its reactive dependencies change.
- */
-export const effect = (fn: () => void): Unsubscribe => StateImpl.createEffect(fn)
+const notifySubscribers = (): void => {
+	if (isNotifying) {
+		return
+	}
 
-/**
- * Groups multiple state updates to trigger effects only once at the end.
- */
-export const batch = <T>(fn: () => T): T => StateImpl.executeBatch(fn)
+	isNotifying = true
 
-/**
- * Creates a read-only computed value that updates when its dependencies change.
- */
-export const derive = <T>(computeFn: () => T): ReadOnlyState<T> => StateImpl.createDerive(computeFn)
+	try {
+		while (pendingSubscribers.size > 0) {
+			const subscribers = pendingSubscribers
+			pendingSubscribers = new Set()
 
-/**
- * Creates an efficient subscription to a subset of a state value.
- */
-export const select = <T, R>(
-	source: ReadOnlyState<T>,
-	selectorFn: (state: T) => R,
-	equalityFn: (a: R, b: R) => boolean = Object.is
-): ReadOnlyState<R> => StateImpl.createSelect(source, selectorFn, equalityFn)
+			for (const effect of subscribers) {
+				effect()
+			}
+		}
+	} finally {
+		isNotifying = false
+	}
+}
 
-/**
- * Creates a read-only view of a state, hiding mutation methods.
- */
-export const readonlyState =
-	<T>(state: State<T>): ReadOnlyState<T> =>
-	(): T =>
-		state()
+const cleanupEffect = (effect: Subscriber): void => {
+	pendingSubscribers.delete(effect)
 
-/**
- * Creates a state with access control, returning a tuple of reader and writer.
- */
-export const protectedState = <T>(
-	initialValue: T,
-	equalityFn: (a: T, b: T) => boolean = Object.is
-): [
-	ReadOnlyState<T>,
-	WriteableState<T>,
-] => {
-	const fullState = state(initialValue, equalityFn)
-	return [
-		(): T => readonlyState(fullState)(),
-		{
-			set: (value: T): void => fullState.set(value),
-			update: (fn: (value: T) => T): void => fullState.update(fn),
-		},
-	]
+	const deps = subscriberDependencies.get(effect)
+	if (deps) {
+		for (const subscribers of deps) {
+			subscribers.delete(effect)
+		}
+		deps.clear()
+		subscriberDependencies.delete(effect)
+	}
 }
 
 /**
- * Creates a lens for direct updates to nested properties of a state.
+ * Creates a reactive state container with the provided initial value.
  */
-export const lens = <T, K>(source: State<T>, accessor: (state: T) => K): State<K> =>
-	StateImpl.createLens(source, accessor)
+const createState = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> => {
+	let value = initialValue
+	const subscribers = new Set<Subscriber>()
+	const stateId = Symbol()
 
-class StateImpl<T> {
-	// Static fields track global reactivity state - this centralized approach allows
-	// for coordinated updates while maintaining individual state isolation
-	private static currentSubscriber: Subscriber | null = null
-	private static pendingSubscribers = new Set<Subscriber>()
-	private static isNotifying = false
-	private static batchDepth = 0
-	private static deferredEffectCreations: Subscriber[] = []
-	private static activeSubscribers = new Set<Subscriber>()
-
-	// WeakMaps enable automatic garbage collection when subscribers are no
-	// longer referenced, preventing memory leaks in long-running applications
-	private static stateTracking = new WeakMap<Subscriber, Set<symbol>>()
-	private static subscriberDependencies = new WeakMap<Subscriber, Set<Set<Subscriber>>>()
-	private static parentSubscriber = new WeakMap<Subscriber, Subscriber>()
-	private static childSubscribers = new WeakMap<Subscriber, Set<Subscriber>>()
-
-	// Instance state - each state has unique subscribers and ID
-	private value: T
-	private subscribers = new Set<Subscriber>()
-	private stateId = Symbol()
-	private equalityFn: (a: T, b: T) => boolean
-
-	constructor(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is) {
-		this.value = initialValue
-		this.equalityFn = equalityFn
-	}
-
-	/**
-	 * Creates a reactive state container with the provided initial value.
-	 * Implementation of the public 'state' function.
-	 */
-	static createState = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = Object.is): State<T> => {
-		const instance = new StateImpl<T>(initialValue, equalityFn)
-		const get = (): T => instance.get()
-		get.set = (value: T): void => instance.set(value)
-		get.update = (fn: (currentValue: T) => T): void => instance.update(fn)
-		get[STATE_ID] = instance.stateId
-		return get as State<T>
-	}
-
-	// Auto-tracks dependencies when called within effects, creating a fine-grained
-	// reactivity graph that only updates affected components
-	get = (): T => {
-		const currentEffect = StateImpl.currentSubscriber
+	const get = (): T => {
+		const currentEffect = currentSubscriber
 		if (currentEffect) {
-			// Add this effect to subscribers for future notification
-			this.subscribers.add(currentEffect)
+			subscribers.add(currentEffect)
 
-			// Maintain bidirectional dependency tracking to enable precise cleanup
-			// when effects are unsubscribed, preventing memory leaks
-			let dependencies = StateImpl.subscriberDependencies.get(currentEffect)
+			let dependencies = subscriberDependencies.get(currentEffect)
 			if (!dependencies) {
 				dependencies = new Set()
-				StateImpl.subscriberDependencies.set(currentEffect, dependencies)
+				subscriberDependencies.set(currentEffect, dependencies)
 			}
-			dependencies.add(this.subscribers)
+			dependencies.add(subscribers)
 
-			// Track read states to detect direct cyclical dependencies that
-			// could cause infinite loops
-			let readStates = StateImpl.stateTracking.get(currentEffect)
+			let readStates = stateTracking.get(currentEffect)
 			if (!readStates) {
 				readStates = new Set()
-				StateImpl.stateTracking.set(currentEffect, readStates)
+				stateTracking.set(currentEffect, readStates)
 			}
-			readStates.add(this.stateId)
+			readStates.add(stateId)
 		}
-		return this.value
+		return value
 	}
 
-	// Handles value updates with built-in optimizations and safeguards
-	set = (newValue: T): void => {
-		// Skip updates for unchanged values to prevent redundant effect executions
-		if (this.equalityFn(this.value, newValue)) {
+	get.set = (newValue: T): void => {
+		if (equalityFn(value, newValue)) {
 			return
 		}
 
-		// Infinite loop detection prevents direct self-mutation within effects,
-		// while allowing nested effect patterns that would otherwise appear cyclical
-		const effect = StateImpl.currentSubscriber
+		const effect = currentSubscriber
 		if (effect) {
-			const states = StateImpl.stateTracking.get(effect)
-			if (states?.has(this.stateId) && !StateImpl.parentSubscriber.get(effect)) {
+			const states = stateTracking.get(effect)
+			if (states?.has(stateId) && !parentSubscriber.get(effect)) {
 				throw new Error('Infinite loop detected: effect() cannot update a state() it depends on!')
 			}
 		}
 
-		this.value = newValue
+		value = newValue
 
-		// Skip updates when there are no subscribers, avoiding unnecessary processing
-		if (this.subscribers.size === 0) {
+		if (subscribers.size === 0) {
 			return
 		}
 
-		// Queue notifications instead of executing immediately to support batch operations
-		// and prevent redundant effect runs
-		for (const sub of this.subscribers) {
-			StateImpl.pendingSubscribers.add(sub)
+		for (const sub of subscribers) {
+			pendingSubscribers.add(sub)
 		}
 
-		// Immediate execution outside of batches, deferred execution inside batches
-		if (StateImpl.batchDepth === 0 && !StateImpl.isNotifying) {
-			StateImpl.notifySubscribers()
+		if (batchDepth === 0 && !isNotifying) {
+			notifySubscribers()
 		}
 	}
 
-	update = (fn: (currentValue: T) => T): void => {
-		this.set(fn(this.value))
+	get.update = (fn: (currentValue: T) => T): void => {
+		get.set(fn(value))
 	}
 
-	/**
-	 * Registers a function to run whenever its reactive dependencies change.
-	 * Implementation of the public 'effect' function.
-	 */
-	static createEffect = (fn: () => void): Unsubscribe => {
-		const runEffect = (): void => {
-			// Prevent re-entrance to avoid cascade updates during effect execution
-			if (StateImpl.activeSubscribers.has(runEffect)) {
-				return
-			}
+	get[STATE_ID] = stateId
+	return get as State<T>
+}
 
-			StateImpl.activeSubscribers.add(runEffect)
-			const parentEffect = StateImpl.currentSubscriber
-
-			try {
-				// Clean existing subscriptions before running to ensure only
-				// currently accessed states are tracked as dependencies
-				StateImpl.cleanupEffect(runEffect)
-
-				// Set current context for automatic dependency tracking
-				StateImpl.currentSubscriber = runEffect
-				StateImpl.stateTracking.set(runEffect, new Set())
-
-				// Track parent-child relationships to handle nested effects correctly
-				// and enable hierarchical cleanup later
-				if (parentEffect) {
-					StateImpl.parentSubscriber.set(runEffect, parentEffect)
-					let children = StateImpl.childSubscribers.get(parentEffect)
-					if (!children) {
-						children = new Set()
-						StateImpl.childSubscribers.set(parentEffect, children)
-					}
-					children.add(runEffect)
-				}
-
-				// Execute the effect function, which will auto-track dependencies
-				fn()
-			} finally {
-				// Restore previous context when done
-				StateImpl.currentSubscriber = parentEffect
-				StateImpl.activeSubscribers.delete(runEffect)
-			}
+/**
+ * Registers a function to run whenever its reactive dependencies change.
+ */
+const createEffect = (fn: () => void): Unsubscribe => {
+	const runEffect = (): void => {
+		if (activeSubscribers.has(runEffect)) {
+			return
 		}
 
-		// Run immediately unless we're in a batch operation
-		if (StateImpl.batchDepth === 0) {
-			runEffect()
-		} else {
-			// Still track parent-child relationship even when deferred,
-			// ensuring proper hierarchical cleanup later
-			if (StateImpl.currentSubscriber) {
-				const parent = StateImpl.currentSubscriber
-				StateImpl.parentSubscriber.set(runEffect, parent)
-				let children = StateImpl.childSubscribers.get(parent)
+		activeSubscribers.add(runEffect)
+		const parentEffect = currentSubscriber
+
+		try {
+			cleanupEffect(runEffect)
+
+			currentSubscriber = runEffect
+			stateTracking.set(runEffect, new Set())
+
+			if (parentEffect) {
+				parentSubscriber.set(runEffect, parentEffect)
+				let children = childSubscribers.get(parentEffect)
 				if (!children) {
 					children = new Set()
-					StateImpl.childSubscribers.set(parent, children)
+					childSubscribers.set(parentEffect, children)
 				}
 				children.add(runEffect)
 			}
 
-			// Queue for execution when batch completes
-			StateImpl.deferredEffectCreations.push(runEffect)
-		}
-
-		// Return cleanup function to properly disconnect from reactivity graph
-		return (): void => {
-			// Remove from dependency tracking to stop future notifications
-			StateImpl.cleanupEffect(runEffect)
-			StateImpl.pendingSubscribers.delete(runEffect)
-			StateImpl.activeSubscribers.delete(runEffect)
-			StateImpl.stateTracking.delete(runEffect)
-
-			// Clean up parent-child relationship bidirectionally
-			const parent = StateImpl.parentSubscriber.get(runEffect)
-			if (parent) {
-				const siblings = StateImpl.childSubscribers.get(parent)
-				if (siblings) {
-					siblings.delete(runEffect)
-				}
-			}
-			StateImpl.parentSubscriber.delete(runEffect)
-
-			// Recursively clean up child effects to prevent memory leaks in
-			// nested effect scenarios
-			const children = StateImpl.childSubscribers.get(runEffect)
-			if (children) {
-				for (const child of children) {
-					StateImpl.cleanupEffect(child)
-				}
-				children.clear()
-				StateImpl.childSubscribers.delete(runEffect)
-			}
-		}
-	}
-
-	/**
-	 * Groups multiple state updates to trigger effects only once at the end.
-	 * Implementation of the public 'batch' function.
-	 */
-	static executeBatch = <T>(fn: () => T): T => {
-		// Increment depth counter to handle nested batches correctly
-		StateImpl.batchDepth++
-		try {
-			return fn()
-		} catch (error: unknown) {
-			// Clean up on error to prevent stale subscribers from executing
-			// and potentially causing cascading errors
-			if (StateImpl.batchDepth === 1) {
-				StateImpl.pendingSubscribers.clear()
-				StateImpl.deferredEffectCreations.length = 0
-			}
-			throw error
+			fn()
 		} finally {
-			StateImpl.batchDepth--
-
-			// Only process effects when exiting the outermost batch,
-			// maintaining proper execution order while avoiding redundant runs
-			if (StateImpl.batchDepth === 0) {
-				// Process effects created during the batch
-				if (StateImpl.deferredEffectCreations.length > 0) {
-					// Swap reference instead of spread copy to avoid array allocation
-					const effectsToRun = StateImpl.deferredEffectCreations
-					StateImpl.deferredEffectCreations = []
-					for (const effect of effectsToRun) {
-						effect()
-					}
-				}
-
-				// Process state updates that occurred during the batch
-				if (StateImpl.pendingSubscribers.size > 0 && !StateImpl.isNotifying) {
-					StateImpl.notifySubscribers()
-				}
-			}
+			currentSubscriber = parentEffect
+			activeSubscribers.delete(runEffect)
 		}
 	}
 
-	/**
-	 * Creates a read-only computed value that updates when its dependencies change.
-	 * Implementation of the public 'derive' function.
-	 */
-	static createDerive = <T>(computeFn: () => T): ReadOnlyState<T> => {
-		// Create a container to hold state and minimize closure captures
-		const container = {
-			cachedValue: undefined as unknown as T,
-			computeFn,
-			initialized: false,
-			valueState: StateImpl.createState<T | undefined>(undefined),
+	if (batchDepth === 0) {
+		runEffect()
+	} else {
+		if (currentSubscriber) {
+			const parent = currentSubscriber
+			parentSubscriber.set(runEffect, parent)
+			let children = childSubscribers.get(parent)
+			if (!children) {
+				children = new Set()
+				childSubscribers.set(parent, children)
+			}
+			children.add(runEffect)
 		}
 
-		// Internal effect automatically tracks dependencies and updates the derived value
-		StateImpl.createEffect(function deriveEffect(): void {
-			const newValue = container.computeFn()
-
-			// Only update if the value actually changed to preserve referential equality
-			// and prevent unnecessary downstream updates
-			if (!(container.initialized && Object.is(container.cachedValue, newValue))) {
-				container.cachedValue = newValue
-				container.valueState.set(newValue)
-			}
-
-			container.initialized = true
-		})
-
-		// Return function with lazy initialization - ensures value is available
-		// even when accessed before its dependencies have had a chance to update
-		return function deriveGetter(): T {
-			if (!container.initialized) {
-				container.cachedValue = container.computeFn()
-				container.initialized = true
-				container.valueState.set(container.cachedValue)
-			}
-			return container.valueState() as T
-		}
+		deferredEffectCreations.push(runEffect)
 	}
 
-	/**
-	 * Creates an efficient subscription to a subset of a state value.
-	 * Implementation of the public 'select' function.
-	 */
-	static createSelect = <T, R>(
-		source: ReadOnlyState<T>,
-		selectorFn: (state: T) => R,
-		equalityFn: (a: R, b: R) => boolean = Object.is
-	): ReadOnlyState<R> => {
-		// Create a container to hold state and minimize closure captures
-		const container = {
-			equalityFn,
-			initialized: false,
-			lastSelectedValue: undefined as R | undefined,
-			lastSourceValue: undefined as T | undefined,
-			selectorFn,
-			source,
-			valueState: StateImpl.createState<R | undefined>(undefined),
-		}
+	return (): void => {
+		cleanupEffect(runEffect)
+		pendingSubscribers.delete(runEffect)
+		activeSubscribers.delete(runEffect)
+		stateTracking.delete(runEffect)
 
-		// Internal effect to track the source and update only when needed
-		StateImpl.createEffect(function selectEffect(): void {
-			const sourceValue = container.source()
-
-			// Skip computation if source reference hasn't changed
-			if (container.initialized && Object.is(container.lastSourceValue, sourceValue)) {
-				return
-			}
-
-			container.lastSourceValue = sourceValue
-			const newSelectedValue = container.selectorFn(sourceValue)
-
-			// Use custom equality function to determine if value semantically changed,
-			// allowing for deep equality comparisons with complex objects
-			if (
-				container.initialized &&
-				container.lastSelectedValue !== undefined &&
-				container.equalityFn(container.lastSelectedValue, newSelectedValue)
-			) {
-				return
-			}
-
-			// Update cache and notify subscribers due the value has changed
-			container.lastSelectedValue = newSelectedValue
-			container.valueState.set(newSelectedValue)
-			container.initialized = true
-		})
-
-		// Return function with eager initialization capability
-		return function selectGetter(): R {
-			if (!container.initialized) {
-				container.lastSourceValue = container.source()
-				container.lastSelectedValue = container.selectorFn(container.lastSourceValue)
-				container.valueState.set(container.lastSelectedValue)
-				container.initialized = true
-			}
-			return container.valueState() as R
-		}
-	}
-
-	/**
-	 * Creates a lens for direct updates to nested properties of a state.
-	 * Implementation of the public 'lens' function.
-	 */
-	static createLens = <T, K>(source: State<T>, accessor: (state: T) => K): State<K> => {
-		// Create a container to hold lens state and minimize closure captures
-		const container = {
-			accessor,
-			isUpdating: false,
-			lensState: null as unknown as State<K>,
-			originalSet: null as unknown as (value: K) => void,
-			path: [] as (string | number)[],
-			source,
-		}
-
-		// Extract the property path once during lens creation
-		const extractPath = (): (string | number)[] => {
-			const pathCollector: (string | number)[] = []
-			const proxy = new Proxy(
-				{},
-				{
-					get: (_: object, prop: string | symbol): unknown => {
-						if (typeof prop === 'string' || typeof prop === 'number') {
-							pathCollector.push(prop)
-						}
-						return proxy
-					},
-				}
-			)
-
-			try {
-				container.accessor(proxy as unknown as T)
-			} catch {
-				// Ignore errors, we're just collecting the path
-			}
-
-			return pathCollector
-		}
-
-		// Capture the path once
-		container.path = extractPath()
-
-		// Create a state with the initial value from the source
-		container.lensState = StateImpl.createState<K>(container.accessor(container.source()))
-		container.originalSet = container.lensState.set
-
-		// Set up an effect to sync from source to lens
-		StateImpl.createEffect(function lensEffect(): void {
-			if (container.isUpdating) {
-				return
-			}
-
-			container.isUpdating = true
-			try {
-				container.lensState.set(container.accessor(container.source()))
-			} finally {
-				container.isUpdating = false
-			}
-		})
-
-		// Override the lens state's set method to update the source
-		container.lensState.set = function lensSet(value: K): void {
-			if (container.isUpdating) {
-				return
-			}
-
-			container.isUpdating = true
-			try {
-				// Update lens state
-				container.originalSet(value)
-
-				// Update source by modifying the value at path
-				container.source.update((current: T): T => setValueAtPath(current, container.path, value))
-			} finally {
-				container.isUpdating = false
+		const parent = parentSubscriber.get(runEffect)
+		if (parent) {
+			const siblings = childSubscribers.get(parent)
+			if (siblings) {
+				siblings.delete(runEffect)
 			}
 		}
+		parentSubscriber.delete(runEffect)
 
-		// Add update method for completeness
-		container.lensState.update = function lensUpdate(fn: (value: K) => K): void {
-			container.lensState.set(fn(container.lensState()))
-		}
-
-		return container.lensState
-	}
-
-	// Processes queued subscriber notifications in a controlled, non-reentrant way
-	private static notifySubscribers = (): void => {
-		// Prevent reentrance to avoid cascading notification loops when
-		// effects trigger further state changes
-		if (StateImpl.isNotifying) {
-			return
-		}
-
-		StateImpl.isNotifying = true
-
-		try {
-			// Process all pending effects in batches for better perf,
-			// ensuring topological execution order is maintained
-			while (StateImpl.pendingSubscribers.size > 0) {
-				// Swap with empty Set instead of Array.from() to avoid array allocation
-				const subscribers = StateImpl.pendingSubscribers
-				StateImpl.pendingSubscribers = new Set()
-
-				for (const effect of subscribers) {
-					effect()
-				}
+		const children = childSubscribers.get(runEffect)
+		if (children) {
+			for (const child of children) {
+				cleanupEffect(child)
 			}
-		} finally {
-			StateImpl.isNotifying = false
-		}
-	}
-
-	// Removes effect from dependency tracking to prevent memory leaks
-	private static cleanupEffect = (effect: Subscriber): void => {
-		// Remove from execution queue to prevent stale updates
-		StateImpl.pendingSubscribers.delete(effect)
-
-		// Remove bidirectional dependency references to prevent memory leaks
-		const deps = StateImpl.subscriberDependencies.get(effect)
-		if (deps) {
-			for (const subscribers of deps) {
-				subscribers.delete(effect)
-			}
-			deps.clear()
-			StateImpl.subscriberDependencies.delete(effect)
+			children.clear()
+			childSubscribers.delete(runEffect)
 		}
 	}
 }
+
+/**
+ * Groups multiple state updates to trigger effects only once at the end.
+ */
+const executeBatch = <T>(fn: () => T): T => {
+	batchDepth++
+	try {
+		return fn()
+	} catch (error: unknown) {
+		if (batchDepth === 1) {
+			pendingSubscribers.clear()
+			deferredEffectCreations.length = 0
+		}
+		throw error
+	} finally {
+		batchDepth--
+
+		if (batchDepth === 0) {
+			if (deferredEffectCreations.length > 0) {
+				const effectsToRun = deferredEffectCreations
+				deferredEffectCreations = []
+				for (const effect of effectsToRun) {
+					effect()
+				}
+			}
+
+			if (pendingSubscribers.size > 0 && !isNotifying) {
+				notifySubscribers()
+			}
+		}
+	}
+}
+
+/**
+ * Creates a read-only computed value that updates when its dependencies change.
+ */
+const createDerive = <T>(computeFn: () => T): ReadOnlyState<T> => {
+	const container = {
+		cachedValue: undefined as unknown as T,
+		computeFn,
+		initialized: false,
+		valueState: createState<T | undefined>(undefined),
+	}
+
+	createEffect(function deriveEffect(): void {
+		const newValue = container.computeFn()
+
+		if (!(container.initialized && Object.is(container.cachedValue, newValue))) {
+			container.cachedValue = newValue
+			container.valueState.set(newValue)
+		}
+
+		container.initialized = true
+	})
+
+	return function deriveGetter(): T {
+		if (!container.initialized) {
+			container.cachedValue = container.computeFn()
+			container.initialized = true
+			container.valueState.set(container.cachedValue)
+		}
+		return container.valueState() as T
+	}
+}
+
+/**
+ * Creates an efficient subscription to a subset of a state value.
+ */
+const createSelect = <T, R>(
+	source: ReadOnlyState<T>,
+	selectorFn: (state: T) => R,
+	equalityFn: (a: R, b: R) => boolean = Object.is
+): ReadOnlyState<R> => {
+	const container = {
+		equalityFn,
+		initialized: false,
+		lastSelectedValue: undefined as R | undefined,
+		lastSourceValue: undefined as T | undefined,
+		selectorFn,
+		source,
+		valueState: createState<R | undefined>(undefined),
+	}
+
+	createEffect(function selectEffect(): void {
+		const sourceValue = container.source()
+
+		if (container.initialized && Object.is(container.lastSourceValue, sourceValue)) {
+			return
+		}
+
+		container.lastSourceValue = sourceValue
+		const newSelectedValue = container.selectorFn(sourceValue)
+
+		if (
+			container.initialized &&
+			container.lastSelectedValue !== undefined &&
+			container.equalityFn(container.lastSelectedValue, newSelectedValue)
+		) {
+			return
+		}
+
+		container.lastSelectedValue = newSelectedValue
+		container.valueState.set(newSelectedValue)
+		container.initialized = true
+	})
+
+	return function selectGetter(): R {
+		if (!container.initialized) {
+			container.lastSourceValue = container.source()
+			container.lastSelectedValue = container.selectorFn(container.lastSourceValue)
+			container.valueState.set(container.lastSelectedValue)
+			container.initialized = true
+		}
+		return container.valueState() as R
+	}
+}
+
 // Helper for array updates
 const updateArrayItem = <V>(arr: unknown[], index: number, value: V): unknown[] => {
 	const copy = [
@@ -587,21 +357,17 @@ const updateArrayPath = <V>(array: unknown[], pathSegments: (string | number)[],
 	const index = Number(pathSegments[0])
 
 	if (pathSegments.length === 1) {
-		// Simple array item update
 		return updateArrayItem(array, index, value)
 	}
 
-	// Nested path in array
 	const copy = [
 		...array,
 	]
 	const nextPathSegments = pathSegments.slice(1)
 	const nextKey = nextPathSegments[0]
 
-	// For null/undefined values in arrays, create appropriate containers
 	let nextValue = array[index]
 	if (nextValue === undefined || nextValue === null) {
-		// Use empty object as default if nextKey is undefined
 		nextValue = nextKey !== undefined ? createContainer(nextKey) : {}
 	}
 
@@ -615,30 +381,23 @@ const updateObjectPath = <V>(
 	pathSegments: (string | number)[],
 	value: V
 ): Record<string | number, unknown> => {
-	// Ensure we have a valid key
 	const currentKey = pathSegments[0]
 	if (currentKey === undefined) {
-		// This shouldn't happen given our checks in the main function
 		return obj
 	}
 
 	if (pathSegments.length === 1) {
-		// Simple object property update
 		return updateShallowProperty(obj, currentKey, value)
 	}
 
-	// Nested path in object
 	const nextPathSegments = pathSegments.slice(1)
 	const nextKey = nextPathSegments[0]
 
-	// For null/undefined values, create appropriate containers
 	let currentValue = obj[currentKey]
 	if (currentValue === undefined || currentValue === null) {
-		// Use empty object as default if nextKey is undefined
 		currentValue = nextKey !== undefined ? createContainer(nextKey) : {}
 	}
 
-	// Create new object with updated property
 	const result = {
 		...obj,
 	}
@@ -646,9 +405,7 @@ const updateObjectPath = <V>(
 	return result
 }
 
-// Simplified function to update a nested value at a path
 const setValueAtPath = <V, O>(obj: O, pathSegments: (string | number)[], value: V): O => {
-	// Handle base cases
 	if (pathSegments.length === 0) {
 		return value as unknown as O
 	}
@@ -662,10 +419,126 @@ const setValueAtPath = <V, O>(obj: O, pathSegments: (string | number)[], value: 
 		return obj
 	}
 
-	// Delegate to specialized handlers based on data type
 	if (Array.isArray(obj)) {
 		return updateArrayPath(obj, pathSegments, value) as unknown as O
 	}
 
 	return updateObjectPath(obj as Record<string | number, unknown>, pathSegments, value) as unknown as O
 }
+
+/**
+ * Creates a lens for direct updates to nested properties of a state.
+ */
+const createLens = <T, K>(source: State<T>, accessor: (state: T) => K): State<K> => {
+	const container = {
+		accessor,
+		isUpdating: false,
+		lensState: null as unknown as State<K>,
+		originalSet: null as unknown as (value: K) => void,
+		path: [] as (string | number)[],
+		source,
+	}
+
+	const extractPath = (): (string | number)[] => {
+		const pathCollector: (string | number)[] = []
+		const proxy = new Proxy(
+			{},
+			{
+				get: (_: object, prop: string | symbol): unknown => {
+					if (typeof prop === 'string' || typeof prop === 'number') {
+						pathCollector.push(prop)
+					}
+					return proxy
+				},
+			}
+		)
+
+		try {
+			container.accessor(proxy as unknown as T)
+		} catch {
+			// Ignore errors, we're just collecting the path
+		}
+
+		return pathCollector
+	}
+
+	container.path = extractPath()
+
+	container.lensState = createState<K>(container.accessor(container.source()))
+	container.originalSet = container.lensState.set
+
+	createEffect(function lensEffect(): void {
+		if (container.isUpdating) {
+			return
+		}
+
+		container.isUpdating = true
+		try {
+			container.lensState.set(container.accessor(container.source()))
+		} finally {
+			container.isUpdating = false
+		}
+	})
+
+	container.lensState.set = function lensSet(value: K): void {
+		if (container.isUpdating) {
+			return
+		}
+
+		container.isUpdating = true
+		try {
+			container.originalSet(value)
+
+			container.source.update((current: T): T => setValueAtPath(current, container.path, value))
+		} finally {
+			container.isUpdating = false
+		}
+	}
+
+	container.lensState.update = function lensUpdate(fn: (value: K) => K): void {
+		container.lensState.set(fn(container.lensState()))
+	}
+
+	return container.lensState
+}
+
+/**
+ * Creates a read-only view of a state, hiding mutation methods.
+ */
+const createReadonlyState =
+	<T>(source: State<T>): ReadOnlyState<T> =>
+	(): T =>
+		source()
+
+/**
+ * Creates a state with access control, returning a tuple of reader and writer.
+ */
+const createProtectedState = <T>(
+	initialValue: T,
+	equalityFn: (a: T, b: T) => boolean = Object.is
+): [
+	ReadOnlyState<T>,
+	WriteableState<T>,
+] => {
+	const fullState = createState(initialValue, equalityFn)
+	return [
+		(): T => createReadonlyState(fullState)(),
+		{
+			set: (value: T): void => fullState.set(value),
+			update: (fn: (value: T) => T): void => fullState.update(fn),
+		},
+	]
+}
+
+export {
+	createDerive as derive,
+	createEffect as effect,
+	createLens as lens,
+	createProtectedState as protectedState,
+	createReadonlyState as readonlyState,
+	createSelect as select,
+	createState as state,
+	executeBatch as batch,
+}
+
+export type { ReadOnlyState, State, Unsubscribe, WriteableState }


### PR DESCRIPTION
## Summary
- Add 15-benchmark suite covering state creation, reads, writes, effect triggers, many dependencies, derive chains, and batch comparisons
- 3 warmup runs, 7 measurement runs, reports median/min/max/sd

## Test plan
- [ ] Run `node scripts/benchmark.ts` — all 15 benchmarks complete without errors