### PR TITLE
fix(ci): migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -128,6 +128,9 @@ jobs:
       - test-lts-22
     if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -150,5 +153,3 @@ jobs:
           name: dist
           path: dist/
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_BEACON_PUBLISH_TOKEN}}


### PR DESCRIPTION
## Summary

- Replace long-lived `NPM_BEACON_PUBLISH_TOKEN` secret with OIDC trusted publishing
- Add `id-token: write` permission to the `publish-npm` job
- Clear `NODE_AUTH_TOKEN` so npm falls through to OIDC token exchange

## Prerequisites

Configure the trusted publisher on npmjs.com:
- Package settings → Publishing access → Trusted Publishers
- Add GitHub Actions: repo `nerdalytics/beacon`, workflow `build-test-publish.yml`

## Test plan

- [x] Trusted publisher configured on npmjs.com
- [x] Merge and verify publish succeeds with OIDC