### PR TITLE
chore(core): add GitHub Pages deploy workflow for handbook

### DIFF
--- a/.github/workflows/deploy-handbook.yml
+++ b/.github/workflows/deploy-handbook.yml
@@ -1,0 +1,48 @@
+name: Deploy Handbook
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'handbook/**'
+  workflow_dispatch:
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: handbook/package-lock.json
+      - name: Install dependencies
+        working-directory: handbook
+        run: npm ci
+      - name: Build handbook
+        working-directory: handbook
+        env:
+          BASE_PATH: /beacon
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: handbook/build
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

GitHub Actions workflow that builds and deploys the handbook to GitHub Pages.

- Triggers on push to `trunk` when `handbook/**` changes, plus manual dispatch
- Two-job pipeline: build (Node 24, npm ci, SvelteKit static build) → deploy (GitHub Pages)
- All actions SHA-pinned with version comments
- Permissions scoped per job

## Test plan

- [ ] Trigger manually via workflow_dispatch after merge
- [ ] Verify https://nerdalytics.github.io/beacon/ loads