### PR TITLE
test(core): add disjoint-property subscriber benchmark

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,7 +1,7 @@
 import { performance } from 'node:perf_hooks'
 import { parseArgs } from 'node:util'
 import type { ReadOnlyState, Unsubscribe } from '../src/index.ts'
-import { batch, derive, effect, state } from '../src/index.ts'
+import { batch, derive, effect, select, state } from '../src/index.ts'
 
 const DEFAULT_RUN_COUNT = 10
 const LOOP_LENGTH = 1_000_000
@@ -19,6 +19,8 @@ const STATE_READ_COUNT = 1_000_000
 const SINGLE_SUB_WRITES = 100_000
 const MANY_SUB_COUNT = 100
 const MANY_SUB_WRITES = 10_000
+const DISJOINT_PROP_COUNT = 100
+const DISJOINT_WRITES = 10_000
 
 const {
 	values,
@@ -345,6 +347,34 @@ function update100StatesBatched(): number {
 	return end - start
 }
 
+function disjointSubscribers(): number {
+	const obj: Record<string, number> = {}
+	for (let i = 0; i < DISJOINT_PROP_COUNT; i++) obj[`p${i}`] = 0
+	const s = state(obj)
+	const cleanups: Unsubscribe[] = []
+	for (let i = 0; i < DISJOINT_PROP_COUNT; i++) {
+		const key = `p${i}`
+		const sel: ReadOnlyState<number> = select(s, (o: Record<string, number>): number => o[key])
+		cleanups.push(
+			effect((): void => {
+				sel()
+			})
+		)
+	}
+	const start = performance.now()
+	for (let i = 0; i < DISJOINT_WRITES; i++) {
+		s.update(
+			(o: Record<string, number>): Record<string, number> => ({
+				...o,
+				p0: i,
+			})
+		)
+	}
+	const end = performance.now()
+	for (const c of cleanups) c()
+	return end - start
+}
+
 type SuiteEntry =
 	| {
 			fn: BenchmarkFn
@@ -417,6 +447,10 @@ const suite: SuiteEntry[] = [
 	{
 		fn: update100StatesBatched,
 		name: '100 states batched        ',
+	},
+	{
+		fn: disjointSubscribers,
+		name: '100 subs disjoint props   ',
 	},
 ]
 


### PR DESCRIPTION
## Summary

- Adds `100 subs disjoint props` benchmark to the benchmark suite
- 100 `select()`-based subscribers on 1 state object, each reading a different property
- Writes to a single property 10,000 times, measuring notification pipeline efficiency when only 1 of N subscribers cares about the changed property

## Test plan

- [ ] `node --expose-gc scripts/benchmark.ts -R 1` completes without error
- [ ] New benchmark line `100 subs disjoint props` appears in output