### PR TITLE
fix(core): stop deleting local branch during PR supersede

### DIFF
--- a/.github/scripts/manage-pr.sh
+++ b/.github/scripts/manage-pr.sh
@@ -12,7 +12,7 @@ PR_TITLE="chore(core): update GitHub Actions to latest versions"
 EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
 if [[ -n "$EXISTING_PR" ]]; then
   echo "Closing existing PR #${EXISTING_PR} to replace with updated version"
-  gh pr close "$EXISTING_PR" --comment "Superseded by a new PR with updated changes." --delete-branch || true
+  gh pr close "$EXISTING_PR" --comment "Superseded by a new PR with updated changes." || true
 fi
 
 # Delete remote branch if it still exists


### PR DESCRIPTION
## Summary

- Removes `--delete-branch` from `gh pr close` in `manage-pr.sh` — it was destroying the local branch that `commit-changes.sh` just created, causing the subsequent `git push` to fail with `src refspec does not match any`
- Remote branch cleanup is already handled explicitly by `git push origin --delete` on lines 19-22, so `--delete-branch` was redundant for that purpose

## Root cause

The 2026-03-30 scheduled run of `check-action-versions.yml` closed PR #46 but failed to create its replacement because `gh pr close --delete-branch` deletes **both** local and remote branches. This left issue #45 dangling with no linked PR.

## Test plan

- [ ] Trigger `check-action-versions` workflow manually and verify it completes successfully
- [ ] Verify old PR is closed, new PR is created, and issue is linked

Closes #45