### PR TITLE
feat(handbook): add LLM-friendly documentation endpoints

### DIFF
--- a/handbook/src/lib/llm-docs.ts
+++ b/handbook/src/lib/llm-docs.ts
@@ -52,9 +52,7 @@ export function readPageMarkdown(version: string, page: string): string {
 	}
 }
 
-/** Return all valid version strings (without leading slash). */
+/** Return all valid version strings (without leading slash), in versions.ts declaration order. */
 export function getValidVersions(): string[] {
-	return [
-		...VALID_VERSIONS,
-	]
+	return versions.map((v) => v.prefix.slice(1))
 }

--- a/handbook/src/lib/llm-docs.ts
+++ b/handbook/src/lib/llm-docs.ts
@@ -1,20 +1,23 @@
 import { readFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { error } from '@sveltejs/kit'
-import { versions } from '$lib/versions'
 import { getAllPages } from '$lib/navigation'
+import { versions } from '$lib/versions'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const ROUTES_DIR = join(__dirname, '..', 'routes')
+const ROUTES_DIR: string = join(process.cwd(), 'src', 'routes')
 
 /** Set of valid version prefixes without leading slash: 'latest', 'v1000.3.1', etc. */
-const VALID_VERSIONS = new Set(versions.map((v) => v.prefix.slice(1)))
+const VALID_VERSIONS: Set<string> = new Set(versions.map((v) => v.prefix.slice(1)))
+
+/** Extract the last segment of an href path (e.g., '/latest/state' → 'state'). */
+export function slugFromHref(href: string): string {
+	return href.split('/').at(-1) ?? ''
+}
 
 /** Get set of valid page slugs for a version prefix (without leading slash). */
 function getValidPages(version: string): Set<string> {
 	const pages = getAllPages(`/${version}`)
-	return new Set(pages.map((p) => p.href.split('/').pop()!))
+	return new Set(pages.map((p) => slugFromHref(p.href)))
 }
 
 /** Validate version param against allowlist. Throws 404 if invalid. Returns the validated version string. */
@@ -51,5 +54,7 @@ export function readPageMarkdown(version: string, page: string): string {
 
 /** Return all valid version strings (without leading slash). */
 export function getValidVersions(): string[] {
-	return [...VALID_VERSIONS]
+	return [
+		...VALID_VERSIONS,
+	]
 }

--- a/handbook/src/lib/llm-docs.ts
+++ b/handbook/src/lib/llm-docs.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { error } from '@sveltejs/kit'
+import { versions } from '$lib/versions'
+import { getAllPages } from '$lib/navigation'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROUTES_DIR = join(__dirname, '..', 'routes')
+
+/** Set of valid version prefixes without leading slash: 'latest', 'v1000.3.1', etc. */
+const VALID_VERSIONS = new Set(versions.map((v) => v.prefix.slice(1)))
+
+/** Get set of valid page slugs for a version prefix (without leading slash). */
+function getValidPages(version: string): Set<string> {
+	const pages = getAllPages(`/${version}`)
+	return new Set(pages.map((p) => p.href.split('/').pop()!))
+}
+
+/** Validate version param against allowlist. Throws 404 if invalid. Returns the validated version string. */
+export function validateVersion(version: string): string {
+	if (!VALID_VERSIONS.has(version)) {
+		error(404, 'Not found. See /llms.txt for available versions and pages.')
+	}
+	return version
+}
+
+/** Validate page param against allowlist for a given version. Throws 404 if invalid. Returns the validated page string. */
+export function validatePage(version: string, page: string): string {
+	const validPages = getValidPages(version)
+	if (!validPages.has(page)) {
+		error(404, 'Not found. See /llms.txt for available versions and pages.')
+	}
+	return page
+}
+
+/** Read a raw +page.md file for a given version and page slug. */
+export function readPageMarkdown(version: string, page: string): string {
+	const safeVersion = validateVersion(version)
+	const safePage = validatePage(safeVersion, page)
+	const filePath = join(ROUTES_DIR, safeVersion, safePage, '+page.md')
+	try {
+		return readFileSync(filePath, 'utf-8')
+	} catch (err: unknown) {
+		if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+			error(404, 'Not found. See /llms.txt for available versions and pages.')
+		}
+		throw err
+	}
+}
+
+/** Return all valid version strings (without leading slash). */
+export function getValidVersions(): string[] {
+	return [...VALID_VERSIONS]
+}

--- a/handbook/src/routes/[version]/[page].md/+server.ts
+++ b/handbook/src/routes/[version]/[page].md/+server.ts
@@ -1,27 +1,45 @@
-import type { RequestHandler } from './$types'
+import { getValidVersions, readPageMarkdown, slugFromHref, validatePage, validateVersion } from '$lib/llm-docs'
 import { getAllPages } from '$lib/navigation'
-import { validateVersion, validatePage, getValidVersions, readPageMarkdown } from '$lib/llm-docs'
+import type { RequestHandler } from './$types'
 
 export const prerender = true
 
-export function entries() {
-	const result: { version: string; page: string }[] = []
+export function entries(): {
+	version: string
+	page: string
+}[] {
+	const result: {
+		version: string
+		page: string
+	}[] = []
 	for (const version of getValidVersions()) {
 		const pages = getAllPages(`/${version}`)
 		for (const p of pages) {
-			const slug = p.href.split('/').pop()!
-			result.push({ version, page: slug })
+			const slug = slugFromHref(p.href)
+			result.push({
+				page: slug,
+				version,
+			})
 		}
 	}
 	return result
 }
 
-export const GET: RequestHandler = ({ params }) => {
+export const GET: RequestHandler = ({
+	params,
+}: {
+	params: {
+		version: string
+		page: string
+	}
+}) => {
 	const version = validateVersion(params.version)
 	const page = validatePage(version, params.page)
 	const body = readPageMarkdown(version, page)
 
 	return new Response(body, {
-		headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
 	})
 }

--- a/handbook/src/routes/[version]/[page].md/+server.ts
+++ b/handbook/src/routes/[version]/[page].md/+server.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from './$types'
+import { getAllPages } from '$lib/navigation'
+import { validateVersion, validatePage, getValidVersions, readPageMarkdown } from '$lib/llm-docs'
+
+export const prerender = true
+
+export function entries() {
+	const result: { version: string; page: string }[] = []
+	for (const version of getValidVersions()) {
+		const pages = getAllPages(`/${version}`)
+		for (const p of pages) {
+			const slug = p.href.split('/').pop()!
+			result.push({ version, page: slug })
+		}
+	}
+	return result
+}
+
+export const GET: RequestHandler = ({ params }) => {
+	const version = validateVersion(params.version)
+	const page = validatePage(version, params.page)
+	const body = readPageMarkdown(version, page)
+
+	return new Response(body, {
+		headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+	})
+}

--- a/handbook/src/routes/[version]/[page].md/+server.ts
+++ b/handbook/src/routes/[version]/[page].md/+server.ts
@@ -1,4 +1,4 @@
-import { getValidVersions, readPageMarkdown, slugFromHref, validatePage, validateVersion } from '$lib/llm-docs'
+import { getValidVersions, readPageMarkdown, slugFromHref } from '$lib/llm-docs'
 import { getAllPages } from '$lib/navigation'
 import type { RequestHandler } from './$types'
 
@@ -33,9 +33,7 @@ export const GET: RequestHandler = ({
 		page: string
 	}
 }) => {
-	const version = validateVersion(params.version)
-	const page = validatePage(version, params.page)
-	const body = readPageMarkdown(version, page)
+	const body = readPageMarkdown(params.version, params.page)
 
 	return new Response(body, {
 		headers: {

--- a/handbook/src/routes/[version]/llms-full.txt/+server.ts
+++ b/handbook/src/routes/[version]/llms-full.txt/+server.ts
@@ -1,25 +1,37 @@
-import type { RequestHandler } from './$types'
+import { getValidVersions, readPageMarkdown, slugFromHref, validateVersion } from '$lib/llm-docs'
 import { getAllPages } from '$lib/navigation'
-import { validateVersion, getValidVersions, readPageMarkdown } from '$lib/llm-docs'
+import type { RequestHandler } from './$types'
 
 export const prerender = true
 
-export function entries() {
-	return getValidVersions().map((version) => ({ version }))
+export function entries(): {
+	version: string
+}[] {
+	return getValidVersions().map((version) => ({
+		version,
+	}))
 }
 
-export const GET: RequestHandler = ({ params }) => {
+export const GET: RequestHandler = ({
+	params,
+}: {
+	params: {
+		version: string
+	}
+}) => {
 	const version = validateVersion(params.version)
 	const pages = getAllPages(`/${version}`)
 
 	const body = pages
 		.map((p) => {
-			const slug = p.href.split('/').pop()!
+			const slug = slugFromHref(p.href)
 			return readPageMarkdown(version, slug)
 		})
 		.join('\n\n')
 
 	return new Response(body, {
-		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+		},
 	})
 }

--- a/handbook/src/routes/[version]/llms-full.txt/+server.ts
+++ b/handbook/src/routes/[version]/llms-full.txt/+server.ts
@@ -27,7 +27,7 @@ export const GET: RequestHandler = ({
 			const slug = slugFromHref(p.href)
 			return readPageMarkdown(version, slug)
 		})
-		.join('\n\n')
+		.join('\n\n---\n\n')
 
 	return new Response(body, {
 		headers: {

--- a/handbook/src/routes/[version]/llms-full.txt/+server.ts
+++ b/handbook/src/routes/[version]/llms-full.txt/+server.ts
@@ -1,0 +1,25 @@
+import type { RequestHandler } from './$types'
+import { getAllPages } from '$lib/navigation'
+import { validateVersion, getValidVersions, readPageMarkdown } from '$lib/llm-docs'
+
+export const prerender = true
+
+export function entries() {
+	return getValidVersions().map((version) => ({ version }))
+}
+
+export const GET: RequestHandler = ({ params }) => {
+	const version = validateVersion(params.version)
+	const pages = getAllPages(`/${version}`)
+
+	const body = pages
+		.map((p) => {
+			const slug = p.href.split('/').pop()!
+			return readPageMarkdown(version, slug)
+		})
+		.join('\n\n')
+
+	return new Response(body, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+	})
+}

--- a/handbook/src/routes/[version]/llms.txt/+server.ts
+++ b/handbook/src/routes/[version]/llms.txt/+server.ts
@@ -1,21 +1,31 @@
-import type { RequestHandler } from './$types'
 import { base } from '$app/paths'
+import { getValidVersions, slugFromHref, validateVersion } from '$lib/llm-docs'
 import { getAllPages } from '$lib/navigation'
-import { validateVersion, getValidVersions } from '$lib/llm-docs'
+import type { RequestHandler } from './$types'
 
 export const prerender = true
 
-export function entries() {
-	return getValidVersions().map((version) => ({ version }))
+export function entries(): {
+	version: string
+}[] {
+	return getValidVersions().map((version) => ({
+		version,
+	}))
 }
 
-export const GET: RequestHandler = ({ params }) => {
+export const GET: RequestHandler = ({
+	params,
+}: {
+	params: {
+		version: string
+	}
+}) => {
 	const version = validateVersion(params.version)
 	const pages = getAllPages(`/${version}`)
 
 	const pageLines = pages
 		.map((p) => {
-			const slug = p.href.split('/').pop()!
+			const slug = slugFromHref(p.href)
 			return `- [${p.title}](${base}/${version}/${slug}.md)`
 		})
 		.join('\n')
@@ -34,6 +44,8 @@ ${pageLines}
 `
 
 	return new Response(body, {
-		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+		},
 	})
 }

--- a/handbook/src/routes/[version]/llms.txt/+server.ts
+++ b/handbook/src/routes/[version]/llms.txt/+server.ts
@@ -1,0 +1,39 @@
+import type { RequestHandler } from './$types'
+import { base } from '$app/paths'
+import { getAllPages } from '$lib/navigation'
+import { validateVersion, getValidVersions } from '$lib/llm-docs'
+
+export const prerender = true
+
+export function entries() {
+	return getValidVersions().map((version) => ({ version }))
+}
+
+export const GET: RequestHandler = ({ params }) => {
+	const version = validateVersion(params.version)
+	const pages = getAllPages(`/${version}`)
+
+	const pageLines = pages
+		.map((p) => {
+			const slug = p.href.split('/').pop()!
+			return `- [${p.title}](${base}/${version}/${slug}.md)`
+		})
+		.join('\n')
+
+	const body = `# Beacon — ${version}
+
+> Reactive state management for JavaScript
+
+## Pages
+
+${pageLines}
+
+## Full documentation
+
+- [All pages merged](${base}/${version}/llms-full.txt)
+`
+
+	return new Response(body, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+	})
+}

--- a/handbook/src/routes/llms.txt/+server.ts
+++ b/handbook/src/routes/llms.txt/+server.ts
@@ -1,0 +1,24 @@
+import type { RequestHandler } from './$types'
+import { base } from '$app/paths'
+import { versions } from '$lib/versions'
+
+export const prerender = true
+
+export const GET: RequestHandler = () => {
+	const versionLines = versions
+		.map((v) => `- [${v.label}](${base}/${v.prefix.slice(1)}/llms.txt)`)
+		.join('\n')
+
+	const body = `# Beacon
+
+> Reactive state management for JavaScript
+
+## Versions
+
+${versionLines}
+`
+
+	return new Response(body, {
+		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+	})
+}

--- a/handbook/src/routes/llms.txt/+server.ts
+++ b/handbook/src/routes/llms.txt/+server.ts
@@ -1,13 +1,11 @@
-import type { RequestHandler } from './$types'
 import { base } from '$app/paths'
 import { versions } from '$lib/versions'
+import type { RequestHandler } from './$types'
 
 export const prerender = true
 
 export const GET: RequestHandler = () => {
-	const versionLines = versions
-		.map((v) => `- [${v.label}](${base}/${v.prefix.slice(1)}/llms.txt)`)
-		.join('\n')
+	const versionLines = versions.map((v) => `- [${v.label}](${base}/${v.prefix.slice(1)}/llms.txt)`).join('\n')
 
 	const body = `# Beacon
 
@@ -19,6 +17,8 @@ ${versionLines}
 `
 
 	return new Response(body, {
-		headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+		},
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `llms.txt`, `llms-full.txt`, and `.md` endpoints following the [llms.txt proposal](https://llmstxt.org/) so LLMs can consume handbook documentation as raw markdown
- All routes are statically prerendered — no runtime server needed
- Input validation uses strict allowlists against `versions.ts` and `navigation.ts`; no user-supplied strings reach filesystem paths

## Endpoints

| URL pattern | Description |
|---|---|
| `/llms.txt` | Version index with links to each version's `llms.txt` |
| `/{version}/llms.txt` | Page index for a specific version |
| `/{version}/llms-full.txt` | All pages merged into one document |
| `/{version}/{page}.md` | Individual page raw markdown with frontmatter |

## Test plan

- [ ] Run `cd handbook && npm run build` — no 404 warnings
- [ ] Verify `build/llms.txt`, `build/latest/llms.txt`, `build/latest/llms-full.txt`, `build/latest/state.md` all exist
- [ ] Verify `diff src/routes/latest/state/+page.md build/latest/state.md` shows no differences
- [ ] Run `npx biome check` and `npx svelte-check` — zero errors