### PR TITLE
chore(handbook): add --save-exact to all npm install instructions

### DIFF
--- a/handbook/src/routes/latest/installation/+page.md
+++ b/handbook/src/routes/latest/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/latest/migration/+page.md
+++ b/handbook/src/routes/latest/migration/+page.md
@@ -24,7 +24,7 @@ Several internal simplifications: closure variables replace container objects in
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.3.1
+npm install @nerdalytics/beacon@1000.3.1 --save-exact
 ```
 
 No code changes required. Existing tests pass without modification.

--- a/handbook/src/routes/v1.0.0/installation/+page.md
+++ b/handbook/src/routes/v1.0.0/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.0.0/installation/+page.md
+++ b/handbook/src/routes/v1000.0.0/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.1.0/installation/+page.md
+++ b/handbook/src/routes/v1000.1.0/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.1.0/migration/+page.md
+++ b/handbook/src/routes/v1000.1.0/migration/+page.md
@@ -39,7 +39,7 @@ Internally, `lens()` extracts the property path from the accessor via a Proxy tr
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.1.0
+npm install @nerdalytics/beacon@1000.1.0 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.1.1/installation/+page.md
+++ b/handbook/src/routes/v1000.1.1/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.1.1/migration/+page.md
+++ b/handbook/src/routes/v1000.1.1/migration/+page.md
@@ -14,7 +14,7 @@ If your bundler or runtime resolved Beacon correctly in v1000.1.0, this patch ha
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.1.1
+npm install @nerdalytics/beacon@1000.1.1 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.2.0/installation/+page.md
+++ b/handbook/src/routes/v1000.2.0/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.2.0/migration/+page.md
+++ b/handbook/src/routes/v1000.2.0/migration/+page.md
@@ -51,7 +51,7 @@ $user.set({ name: 'Grace', age: 36 })
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.2.0
+npm install @nerdalytics/beacon@1000.2.0 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.2.1/installation/+page.md
+++ b/handbook/src/routes/v1000.2.1/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.2.1/migration/+page.md
+++ b/handbook/src/routes/v1000.2.1/migration/+page.md
@@ -8,7 +8,7 @@ Patch release. Biome configuration, TypeScript config, and benchmark script upda
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.2.1
+npm install @nerdalytics/beacon@1000.2.1 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.2.2/installation/+page.md
+++ b/handbook/src/routes/v1000.2.2/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.2.2/migration/+page.md
+++ b/handbook/src/routes/v1000.2.2/migration/+page.md
@@ -27,7 +27,7 @@ Additive change. Existing code that infers the type works without modification.
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.2.2
+npm install @nerdalytics/beacon@1000.2.2 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.2.3/installation/+page.md
+++ b/handbook/src/routes/v1000.2.3/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.2.3/migration/+page.md
+++ b/handbook/src/routes/v1000.2.3/migration/+page.md
@@ -8,7 +8,7 @@ Patch release. CI workflows restructured, `.gitignore`/`.gitattributes` cleaned 
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.2.3
+npm install @nerdalytics/beacon@1000.2.3 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.2.4/installation/+page.md
+++ b/handbook/src/routes/v1000.2.4/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.2.4/migration/+page.md
+++ b/handbook/src/routes/v1000.2.4/migration/+page.md
@@ -20,7 +20,7 @@ Both eliminate allocation during flush. Most visible in batches with many effect
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.2.4
+npm install @nerdalytics/beacon@1000.2.4 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.2.5/installation/+page.md
+++ b/handbook/src/routes/v1000.2.5/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.2.5/migration/+page.md
+++ b/handbook/src/routes/v1000.2.5/migration/+page.md
@@ -8,7 +8,7 @@ Patch release. README moved from repository root to `.github/README.md`. No sour
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.2.5
+npm install @nerdalytics/beacon@1000.2.5 --save-exact
 ```
 
 No code changes required.

--- a/handbook/src/routes/v1000.3.0/installation/+page.md
+++ b/handbook/src/routes/v1000.3.0/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.3.0/migration/+page.md
+++ b/handbook/src/routes/v1000.3.0/migration/+page.md
@@ -32,7 +32,7 @@ All behavior is identical to v1000.2.5. Tests pass without modification. The eig
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.3.0
+npm install @nerdalytics/beacon@1000.3.0 --save-exact
 ```
 
 Update any bare type imports to use `import type`. No other code changes required.

--- a/handbook/src/routes/v1000.3.1/installation/+page.md
+++ b/handbook/src/routes/v1000.3.1/installation/+page.md
@@ -11,7 +11,7 @@ description: Install Beacon and set up your project
 ## Install
 
 ```bash
-npm install @nerdalytics/beacon
+npm install @nerdalytics/beacon --save-exact
 ```
 
 ## Project setup

--- a/handbook/src/routes/v1000.3.1/migration/+page.md
+++ b/handbook/src/routes/v1000.3.1/migration/+page.md
@@ -24,7 +24,7 @@ Several internal simplifications: closure variables replace container objects in
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.3.1
+npm install @nerdalytics/beacon@1000.3.1 --save-exact
 ```
 
 No code changes required. Existing tests pass without modification.


### PR DESCRIPTION
## Summary

- Append `--save-exact` to all `npm install` commands across 13 installation pages and 11 migration pages
- Prevents unintended semver drift from caret/tilde ranges in consumer projects

## Files changed

24 handbook source files under `handbook/src/routes/*/installation/+page.md` and `handbook/src/routes/*/migration/+page.md`.

## Test plan

- [ ] Verify all install commands render correctly in the handbook
- [ ] Confirm no commands were missed: `grep -r "npm install @nerdalytics/beacon" handbook/src/ | grep -v save-exact` returns empty