### PR TITLE
fix(core): add proto-key denylist to lens path extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
 	"sideEffects": false,
 	"type": "module",
 	"types": "dist/src/index.d.ts",
-	"version": "1000.3.1"
+	"version": "1000.3.2"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const subscriberDependencies: WeakMap<Subscriber, Set<Set<Subscriber>>> = new We
 >()
 const parentSubscriber: WeakMap<Subscriber, Subscriber> = new WeakMap<Subscriber, Subscriber>()
 const childSubscribers: WeakMap<Subscriber, Set<Subscriber>> = new WeakMap<Subscriber, Set<Subscriber>>()
+const DANGEROUS_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype'])
 
 const getOrCreate = <K extends object, V>(map: WeakMap<K, V>, key: K, factory: () => V): V => {
 	let value = map.get(key)
@@ -384,12 +385,17 @@ const createLens = <T, K>(source: State<T>, accessor: (state: T) => K): State<K>
 
 	const extractPath = (): (string | number)[] => {
 		const pathCollector: (string | number)[] = []
+		let tainted = false
 		const proxy = new Proxy(
 			{},
 			{
 				get: (_: object, prop: string | symbol): unknown => {
-					if (typeof prop === 'string' || typeof prop === 'number') {
-						pathCollector.push(prop)
+					if (!tainted && (typeof prop === 'string' || typeof prop === 'number')) {
+						if (DANGEROUS_KEYS.has(String(prop))) {
+							tainted = true
+						} else {
+							pathCollector.push(prop)
+						}
 					}
 					return proxy
 				},
@@ -402,7 +408,7 @@ const createLens = <T, K>(source: State<T>, accessor: (state: T) => K): State<K>
 			// Ignore errors, we're just collecting the path
 		}
 
-		return pathCollector
+		return tainted ? [] : pathCollector
 	}
 
 	const path = extractPath()
@@ -423,7 +429,7 @@ const createLens = <T, K>(source: State<T>, accessor: (state: T) => K): State<K>
 	})
 
 	lensState.set = function lensSet(value: K): void {
-		if (isUpdating) {
+		if (isUpdating || path.length === 0) {
 			return
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,11 @@ const subscriberDependencies: WeakMap<Subscriber, Set<Set<Subscriber>>> = new We
 >()
 const parentSubscriber: WeakMap<Subscriber, Subscriber> = new WeakMap<Subscriber, Subscriber>()
 const childSubscribers: WeakMap<Subscriber, Set<Subscriber>> = new WeakMap<Subscriber, Set<Subscriber>>()
-const DANGEROUS_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype'])
+const DANGEROUS_KEYS: ReadonlySet<string> = new Set([
+	'__proto__',
+	'constructor',
+	'prototype',
+])
 
 const getOrCreate = <K extends object, V>(map: WeakMap<K, V>, key: K, factory: () => V): V => {
 	let value = map.get(key)

--- a/tests/lens.test.ts
+++ b/tests/lens.test.ts
@@ -544,7 +544,8 @@ describe('Lens', {
 				},
 			})
 
-			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).nested.__proto__)
+			// biome-ignore lint/suspicious/noExplicitAny: intentionally testing dangerous path traversal
+			const maliciousLens = lens($source, (s: Target): unknown => (s as any).nested.__proto__)
 
 			// Write should be silently ignored
 			maliciousLens.set({

--- a/tests/lens.test.ts
+++ b/tests/lens.test.ts
@@ -474,16 +474,20 @@ describe('Lens', {
 			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).__proto__)
 
 			// Write should be silently ignored
-			maliciousLens.set({ polluted: true })
+			maliciousLens.set({
+				polluted: true,
+			})
 
 			// Source state must be unchanged
-			assert.deepStrictEqual($source(), { name: 'Alice' })
+			assert.deepStrictEqual($source(), {
+				name: 'Alice',
+			})
 
 			// Object.prototype must not be polluted
 			assert.strictEqual(({} as Record<string, unknown>).polluted, undefined)
 		})
 
-		it('should silently ignore writes through constructor.prototype path', (): void => {
+		it('should silently ignore writes through constructor path', (): void => {
 			type Target = {
 				value: number
 			}
@@ -495,10 +499,64 @@ describe('Lens', {
 			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).constructor)
 
 			// Write should be silently ignored
-			maliciousLens.set({ polluted: true })
+			maliciousLens.set({
+				polluted: true,
+			})
 
 			// Source state must be unchanged
-			assert.deepStrictEqual($source(), { value: 42 })
+			assert.deepStrictEqual($source(), {
+				value: 42,
+			})
+		})
+
+		it('should silently ignore writes through prototype path', (): void => {
+			type Target = {
+				value: number
+			}
+
+			const $source = state<Target>({
+				value: 42,
+			})
+
+			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).prototype)
+
+			// Write should be silently ignored
+			maliciousLens.set({
+				polluted: true,
+			})
+
+			// Source state must be unchanged
+			assert.deepStrictEqual($source(), {
+				value: 42,
+			})
+		})
+
+		it('should silently ignore writes when dangerous key appears mid-path', (): void => {
+			type Target = {
+				nested: {
+					value: string
+				}
+			}
+
+			const $source = state<Target>({
+				nested: {
+					value: 'original',
+				},
+			})
+
+			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).nested.__proto__)
+
+			// Write should be silently ignored
+			maliciousLens.set({
+				polluted: true,
+			})
+
+			// Source state must be unchanged — 'nested' should not be overwritten
+			assert.deepStrictEqual($source(), {
+				nested: {
+					value: 'original',
+				},
+			})
 		})
 	})
 })

--- a/tests/lens.test.ts
+++ b/tests/lens.test.ts
@@ -458,4 +458,47 @@ describe('Lens', {
 			]
 		)
 	})
+
+	describe('Lens security', {
+		concurrency: true,
+	}, (): void => {
+		it('should silently ignore writes through __proto__ path', (): void => {
+			type Target = {
+				name: string
+			}
+
+			const $source = state<Target>({
+				name: 'Alice',
+			})
+
+			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).__proto__)
+
+			// Write should be silently ignored
+			maliciousLens.set({ polluted: true })
+
+			// Source state must be unchanged
+			assert.deepStrictEqual($source(), { name: 'Alice' })
+
+			// Object.prototype must not be polluted
+			assert.strictEqual(({} as Record<string, unknown>).polluted, undefined)
+		})
+
+		it('should silently ignore writes through constructor.prototype path', (): void => {
+			type Target = {
+				value: number
+			}
+
+			const $source = state<Target>({
+				value: 42,
+			})
+
+			const maliciousLens = lens($source, (s: Target): unknown => (s as Record<string, unknown>).constructor)
+
+			// Write should be silently ignored
+			maliciousLens.set({ polluted: true })
+
+			// Source state must be unchanged
+			assert.deepStrictEqual($source(), { value: 42 })
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- Adds a `DANGEROUS_KEYS` denylist (`__proto__`, `constructor`, `prototype`) to the lens `extractPath` Proxy trap
- Dangerous path segments taint the entire path, resulting in a silent write no-op
- Empty-path guard in `lensSet` prevents tainted lenses from replacing source state
- Four security tests covering each denylist key and mid-path dangerous key detection

Closes #62