### PR TITLE
feat(handbook): add v1000.3.2 entry and refactor navigation config

### DIFF
--- a/handbook/src/lib/navigation.ts
+++ b/handbook/src/lib/navigation.ts
@@ -10,1014 +10,210 @@ export interface NavGroup {
 	title: string
 }
 
-export const navigation: Record<string, NavGroup[]> = {
-	'/latest': [
-		{
-			items: [
-				{
-					href: '/latest/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/latest/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/latest/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/latest/state',
-					title: 'State',
-				},
-				{
-					href: '/latest/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/latest/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/latest/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/latest/select',
-					title: 'Select',
-				},
-				{
-					href: '/latest/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/latest/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/latest/migration',
-					title: 'v1000.3.0 → v1000.3.1',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/latest/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/latest/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1.0.0': [
-		{
-			items: [
-				{
-					href: '/v1.0.0/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1.0.0/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1.0.0/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1.0.0/state',
-					title: 'State',
-				},
-				{
-					href: '/v1.0.0/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1.0.0/derived',
-					title: 'Derived',
-				},
-				{
-					href: '/v1.0.0/batch',
-					title: 'Batch',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1.0.0/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1.0.0/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1.0.0/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.0.0': [
-		{
-			items: [
-				{
-					href: '/v1000.0.0/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.0.0/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.0.0/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.0.0/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.0.0/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.0.0/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.0.0/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.0.0/select',
-					title: 'Select',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.0.0/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.0.0/migration',
-					title: 'v1.0.0 → v1000.0.0',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.0.0/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.0.0/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.1.0': [
-		{
-			items: [
-				{
-					href: '/v1000.1.0/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.1.0/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.1.0/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.0/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.1.0/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.1.0/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.1.0/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.1.0/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.1.0/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.0/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.0/migration',
-					title: 'v1000.0.0 → v1000.1.0',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.0/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.1.0/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.1.1': [
-		{
-			items: [
-				{
-					href: '/v1000.1.1/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.1.1/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.1.1/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.1/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.1.1/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.1.1/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.1.1/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.1.1/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.1.1/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.1/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.1/migration',
-					title: 'v1000.1.0 → v1000.1.1',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.1.1/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.1.1/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.2.0': [
-		{
-			items: [
-				{
-					href: '/v1000.2.0/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.2.0/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.2.0/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.0/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.2.0/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.2.0/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.2.0/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.2.0/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.2.0/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.0/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.0/migration',
-					title: 'v1000.1.1 → v1000.2.0',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.0/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.2.0/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.2.1': [
-		{
-			items: [
-				{
-					href: '/v1000.2.1/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.2.1/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.2.1/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.1/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.2.1/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.2.1/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.2.1/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.2.1/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.2.1/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.1/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.1/migration',
-					title: 'v1000.2.0 → v1000.2.1',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.1/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.2.1/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.2.2': [
-		{
-			items: [
-				{
-					href: '/v1000.2.2/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.2.2/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.2.2/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.2/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.2.2/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.2.2/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.2.2/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.2.2/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.2.2/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.2/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.2/migration',
-					title: 'v1000.2.1 → v1000.2.2',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.2/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.2.2/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.2.3': [
-		{
-			items: [
-				{
-					href: '/v1000.2.3/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.2.3/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.2.3/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.3/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.2.3/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.2.3/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.2.3/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.2.3/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.2.3/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.3/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.3/migration',
-					title: 'v1000.2.2 → v1000.2.3',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.3/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.2.3/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.2.4': [
-		{
-			items: [
-				{
-					href: '/v1000.2.4/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.2.4/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.2.4/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.4/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.2.4/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.2.4/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.2.4/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.2.4/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.2.4/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.4/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.4/migration',
-					title: 'v1000.2.3 → v1000.2.4',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.4/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.2.4/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.2.5': [
-		{
-			items: [
-				{
-					href: '/v1000.2.5/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.2.5/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.2.5/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.5/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.2.5/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.2.5/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.2.5/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.2.5/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.2.5/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.5/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.5/migration',
-					title: 'v1000.2.4 → v1000.2.5',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.2.5/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.2.5/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.3.0': [
-		{
-			items: [
-				{
-					href: '/v1000.3.0/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.3.0/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.3.0/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.0/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.3.0/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.3.0/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.3.0/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.3.0/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.3.0/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.0/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.0/migration',
-					title: 'v1000.2.5 → v1000.3.0',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.0/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.3.0/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
-	'/v1000.3.1': [
-		{
-			items: [
-				{
-					href: '/v1000.3.1/introduction',
-					title: 'Introduction',
-				},
-				{
-					href: '/v1000.3.1/installation',
-					title: 'Installation',
-				},
-				{
-					href: '/v1000.3.1/quick-start',
-					title: 'Quick Start',
-				},
-			],
-			title: 'Getting Started',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.1/state',
-					title: 'State',
-				},
-				{
-					href: '/v1000.3.1/effects',
-					title: 'Effects',
-				},
-				{
-					href: '/v1000.3.1/derive',
-					title: 'Derive',
-				},
-				{
-					href: '/v1000.3.1/batch',
-					title: 'Batch',
-				},
-				{
-					href: '/v1000.3.1/select',
-					title: 'Select',
-				},
-				{
-					href: '/v1000.3.1/lens',
-					title: 'Lens',
-				},
-			],
-			title: 'Guides',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.1/architecture',
-					title: 'Architecture',
-				},
-			],
-			title: 'Advanced',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.1/migration',
-					title: 'v1000.3.0 → v1000.3.1',
-				},
-			],
-			title: 'Migration',
-		},
-		{
-			items: [
-				{
-					href: '/v1000.3.1/llms',
-					title: 'LLM Documentation',
-				},
-				{
-					href: '/v1000.3.1/links',
-					title: 'Resources',
-				},
-			],
-			title: 'Links',
-		},
-	],
+interface NavConfig {
+	deriveName?: string
+	hasLens?: boolean
+	hasSelect?: boolean
+	migration?: string
 }
+
+const buildNav = (prefix: string, config: NavConfig = {}): NavGroup[] => {
+	const { deriveName = 'Derive', hasLens = true, hasSelect = true, migration } = config
+
+	const guides: NavItem[] = [
+		{
+			href: `${prefix}/state`,
+			title: 'State',
+		},
+		{
+			href: `${prefix}/effects`,
+			title: 'Effects',
+		},
+		{
+			href: `${prefix}/${deriveName.toLowerCase()}`,
+			title: deriveName,
+		},
+		{
+			href: `${prefix}/batch`,
+			title: 'Batch',
+		},
+	]
+
+	if (hasSelect) {
+		guides.push({
+			href: `${prefix}/select`,
+			title: 'Select',
+		})
+	}
+
+	if (hasLens) {
+		guides.push({
+			href: `${prefix}/lens`,
+			title: 'Lens',
+		})
+	}
+
+	const groups: NavGroup[] = [
+		{
+			items: [
+				{
+					href: `${prefix}/introduction`,
+					title: 'Introduction',
+				},
+				{
+					href: `${prefix}/installation`,
+					title: 'Installation',
+				},
+				{
+					href: `${prefix}/quick-start`,
+					title: 'Quick Start',
+				},
+			],
+			title: 'Getting Started',
+		},
+		{
+			items: guides,
+			title: 'Guides',
+		},
+		{
+			items: [
+				{
+					href: `${prefix}/architecture`,
+					title: 'Architecture',
+				},
+			],
+			title: 'Advanced',
+		},
+	]
+
+	if (migration) {
+		groups.push({
+			items: [
+				{
+					href: `${prefix}/migration`,
+					title: migration,
+				},
+			],
+			title: 'Migration',
+		})
+	}
+
+	groups.push({
+		items: [
+			{
+				href: `${prefix}/llms`,
+				title: 'LLM Documentation',
+			},
+			{
+				href: `${prefix}/links`,
+				title: 'Resources',
+			},
+		],
+		title: 'Links',
+	})
+
+	return groups
+}
+
+const versionConfigs: [
+	string,
+	NavConfig,
+][] = [
+	[
+		'/latest',
+		{
+			migration: 'v1000.3.1 \u2192 v1000.3.2',
+		},
+	],
+	[
+		'/v1000.3.2',
+		{
+			migration: 'v1000.3.1 \u2192 v1000.3.2',
+		},
+	],
+	[
+		'/v1000.3.1',
+		{
+			migration: 'v1000.3.0 \u2192 v1000.3.1',
+		},
+	],
+	[
+		'/v1000.3.0',
+		{
+			migration: 'v1000.2.5 \u2192 v1000.3.0',
+		},
+	],
+	[
+		'/v1000.2.5',
+		{
+			migration: 'v1000.2.4 \u2192 v1000.2.5',
+		},
+	],
+	[
+		'/v1000.2.4',
+		{
+			migration: 'v1000.2.3 \u2192 v1000.2.4',
+		},
+	],
+	[
+		'/v1000.2.3',
+		{
+			migration: 'v1000.2.2 \u2192 v1000.2.3',
+		},
+	],
+	[
+		'/v1000.2.2',
+		{
+			migration: 'v1000.2.1 \u2192 v1000.2.2',
+		},
+	],
+	[
+		'/v1000.2.1',
+		{
+			migration: 'v1000.2.0 \u2192 v1000.2.1',
+		},
+	],
+	[
+		'/v1000.2.0',
+		{
+			migration: 'v1000.1.1 \u2192 v1000.2.0',
+		},
+	],
+	[
+		'/v1000.1.1',
+		{
+			migration: 'v1000.1.0 \u2192 v1000.1.1',
+		},
+	],
+	[
+		'/v1000.1.0',
+		{
+			migration: 'v1000.0.0 \u2192 v1000.1.0',
+		},
+	],
+	[
+		'/v1000.0.0',
+		{
+			hasLens: false,
+			migration: 'v1.0.0 \u2192 v1000.0.0',
+		},
+	],
+	[
+		'/v1.0.0',
+		{
+			deriveName: 'Derived',
+			hasLens: false,
+			hasSelect: false,
+		},
+	],
+]
+
+export const navigation: Record<string, NavGroup[]> = Object.fromEntries(
+	versionConfigs.map(([prefix, config]) => [
+		prefix,
+		buildNav(prefix, config),
+	])
+)
 
 /** Extract the version prefix from a URL path (e.g., "/beacon/v1.0.0/state" -> "/v1.0.0", "/beacon/latest/state" -> "/latest") */
 export function getVersionPrefix(pathname: string): string | undefined {

--- a/handbook/src/lib/versions.ts
+++ b/handbook/src/lib/versions.ts
@@ -21,6 +21,14 @@ export const versions: Version[] = [
 			node: 'https://img.shields.io/badge/node-%3E%3D20.0.0-339933?style=flat-square&logo=nodedotjs&logoColor=white',
 		},
 		current: true,
+		label: 'v1000.3.2',
+		prefix: '/v1000.3.2',
+	},
+	{
+		badges: {
+			node: 'https://img.shields.io/badge/node-%3E%3D20.0.0-339933?style=flat-square&logo=nodedotjs&logoColor=white',
+		},
+		current: false,
 		label: 'v1000.3.1',
 		prefix: '/v1000.3.1',
 	},

--- a/handbook/src/routes/latest/+page.svelte
+++ b/handbook/src/routes/latest/+page.svelte
@@ -23,11 +23,11 @@
 		<a href="https://pnpm.io/">
 			<img src="https://img.shields.io/badge/pnpm-F69220?style=flat-square&logo=pnpm&logoColor=white" alt="pnpm" />
 		</a>
-		<a href="https://www.npmjs.com/package/@nerdalytics/beacon/v/1000.3.1">
-			<img src="https://flat.badgen.net/static/npm/v1000.3.1/blue" alt="npm v1000.3.1" />
+		<a href="https://www.npmjs.com/package/@nerdalytics/beacon/v/1000.3.2">
+			<img src="https://flat.badgen.net/static/npm/v1000.3.2/blue" alt="npm v1000.3.2" />
 		</a>
-		<a href="https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.3.1">
-			<img src="https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.3.1" alt="Socket" />
+		<a href="https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.3.2">
+			<img src="https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.3.2" alt="Socket" />
 		</a>
 	</div>
 	<div class="mb-5 flex items-center gap-1.5 flex-wrap justify-center">

--- a/handbook/src/routes/latest/lens/+page.md
+++ b/handbook/src/routes/latest/lens/+page.md
@@ -105,6 +105,22 @@ $theme.set('dark')
 console.log($config().theme) // => "dark"
 ```
 
+## Path safety
+
+`lens()` rejects three property names: `__proto__`, `constructor`, and `prototype`. If the accessor traverses any of these keys, the lens silently ignores writes. Reads continue to work.
+
+This is a defense-in-depth measure against prototype pollution. Modern JavaScript engines handle the specific code path safely today, but the guard removes the dependency on engine behavior. The denylist is checked once during path extraction, not on every read or write.
+
+```typescript
+const $user = state({ name: 'Alice' })
+
+// This lens can read but will not write back
+const $noop = lens($user, (u) => (u as any).__proto__)
+$noop.set({ polluted: true })
+
+console.log($user()) // => { name: 'Alice' } — unchanged
+```
+
 ## Reactivity
 
 Like any `State<K>`, a lens works with effects and derive:

--- a/handbook/src/routes/latest/migration/+page.md
+++ b/handbook/src/routes/latest/migration/+page.md
@@ -1,30 +1,28 @@
 ---
-title: v1000.3.0 → v1000.3.1
-description: Migrating from Beacon v1000.3.0 to v1000.3.1
+title: v1000.3.1 → v1000.3.2
+description: Migrating from Beacon v1000.3.1 to v1000.3.2
 ---
 
 No API changes. No breaking changes. Drop-in upgrade.
 
-This release reduces allocations in three hot paths. The public interface, behavior, and type signatures are identical to v1000.3.0.
+This release adds a proto-key denylist to lens path extraction. The public interface, behavior, and type signatures are identical to v1000.3.1.
 
 ## What changed
 
-`protectedState` previously created a new readonly wrapper function on every read. It now caches the wrapper once at construction time.
+`lens()` now rejects `__proto__`, `constructor`, and `prototype` as path segments. If an accessor traverses one of these keys, the lens treats the path as invalid and silently ignores writes. Reads still reflect the source value.
 
-Effects that re-run used to allocate a fresh `Set` for dependency tracking each cycle. The existing Set is now cleared and reused.
+The guard runs once during path extraction via a `tainted` flag in the Proxy trap. When a dangerous key appears at any depth in the path, the entire path is discarded, not just the offending segment. This prevents orphaned child segments from writing to unintended properties.
 
-`lens` path updates called `Array.slice()` at each recursion level when writing to nested properties, allocating O(n) intermediate arrays on a path of depth n. These now use index-based iteration with zero intermediate allocations.
+`lensSet` checks for an empty path and returns early, making the write a no-op. `lensUpdate` delegates to `lensSet`, so both write methods are covered.
 
-## Internal
+## Why
 
-The unsubscribe path for nested effects now fully cleans up child references in `activeSubscribers`, `stateTracking`, and `parentSubscriber`. Previously, only the dependency subscriptions were removed, leaving unreachable entries in those WeakMaps until garbage collection. This was not observable in behavior or tests, but it delayed memory reclamation in long-lived applications with frequent effect creation and disposal.
-
-Several internal simplifications: closure variables replace container objects in `derive`, `select`, and `lens`; a shared `getOrCreate` helper replaces four duplicated WeakMap lookup blocks; `updateArrayPath` and `updateObjectPath` are inlined into `setValueAtPath`.
+Prototype pollution through `constructor.prototype` is a known attack vector with multiple CVEs in libraries like lodash, protobuf.js, and tree-kit. Beacon's spread-then-assign pattern in `setValueAtPath` is safe on current V8, but that safety comes from engine behavior, not explicit guards. The denylist makes the safety explicit.
 
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.3.1 --save-exact
+npm install @nerdalytics/beacon@1000.3.2 --save-exact
 ```
 
 No code changes required. Existing tests pass without modification.

--- a/handbook/src/routes/v1000.3.2/+layout.svelte
+++ b/handbook/src/routes/v1000.3.2/+layout.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let { children } = $props()
+</script>
+
+{@render children()}

--- a/handbook/src/routes/v1000.3.2/+page.svelte
+++ b/handbook/src/routes/v1000.3.2/+page.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { asset, resolve } from '$app/paths'
+</script>
+
+<svelte:head>
+	<title>Beacon v1000.3.2 — Reactive dependency graph runtime for Node.js</title>
+	<meta
+		name="description"
+		content="Zero-dependency reactive signal library for Node.js backends. Automatic dependency tracking, select, and efficient updates."
+	/>
+</svelte:head>
+
+<div class="flex-1 flex flex-col items-center justify-center text-center px-4 py-10 lg:py-20 min-h-0 lg:min-h-[80vh] page-enter">
+	<img src={asset('/favicon.svg')} alt="Beacon logo" class="w-28 h-28 mb-3"  />
+	<div class="mb-3 text-7xl font-extrabold beacon-gradient-text">
+		Beacon
+	</div>
+
+	<div class="mb-2 flex items-center gap-1.5 flex-wrap justify-center">
+		<a href="https://yarnpkg.com/">
+			<img src="https://img.shields.io/badge/yarn-2C8EBB?style=flat-square&logo=yarn&logoColor=white" alt="yarn" />
+		</a>
+		<a href="https://pnpm.io/">
+			<img src="https://img.shields.io/badge/pnpm-F69220?style=flat-square&logo=pnpm&logoColor=white" alt="pnpm" />
+		</a>
+		<a href="https://www.npmjs.com/package/@nerdalytics/beacon/v/1000.3.2">
+			<img src="https://flat.badgen.net/static/npm/v1000.3.2/blue" alt="npm v1000.3.2" />
+		</a>
+		<a href="https://socket.dev/npm/package/@nerdalytics/beacon/overview/1000.3.2">
+			<img src="https://badge.socket.dev/npm/package/@nerdalytics/beacon/1000.3.2" alt="Socket" />
+		</a>
+	</div>
+	<div class="mb-5 flex items-center gap-1.5 flex-wrap justify-center">
+		<a href="https://nodejs.org/">
+			<img src="https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="Node.js" />
+		</a>
+		<a href="https://typescriptlang.org/">
+			<img src="https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript" />
+		</a>
+		<a href="https://biomejs.dev/">
+			<img src="https://img.shields.io/badge/Biome-60a5fa?style=for-the-badge&logo=biome&logoColor=white" alt="Biome" />
+		</a>
+		<a href="https://github.com/nerdalytics/beacon/blob/trunk/LICENSE">
+			<img src="https://img.shields.io/badge/MIT-blue?style=for-the-badge" alt="MIT License" />
+		</a>
+	</div>
+
+	<p class="text-lg text-text-muted max-w-lg mb-8 font-serif leading-relaxed">
+		Reactive dependency graph runtime for Node.js
+	</p>
+
+	<div
+		class="mb-8 w-full max-w-md text-left rounded-lg border border-navy-border bg-navy-light p-5 text-sm font-mono leading-relaxed"
+	>
+		<div class="text-lime mb-1">// select a slice, react to it</div>
+		<div>
+			<span class="text-teal">const</span> $user = <span class="text-blue-mid">state</span>({'{'} name: <span class="text-[#e8a46e]">'Ada'</span>, role: <span class="text-[#e8a46e]">'dev'</span> {'}'})
+		</div>
+		<div>
+			<span class="text-teal">const</span> $name = <span class="text-blue-mid">select</span>($user, (u) =&gt; u.name)
+		</div>
+		<div>
+			<span class="text-blue-mid">effect</span>(() =&gt; <span class="text-blue-mid">console</span>.<span class="text-blue-mid">log</span>($name()))
+		</div>
+		<div>
+			$user.<span class="text-blue-mid">update</span>((u) =&gt; ({'{'} ...u, name: <span class="text-[#e8a46e]">'Grace'</span> {'}'}))
+		</div>
+	</div>
+
+	<a
+		href={resolve('/v1000.3.2/introduction')}
+		class="inline-block px-8 py-3 rounded-lg font-sans font-semibold text-navy bg-gradient-to-r from-teal to-blue-mid hover:opacity-90 transition-opacity"
+	>
+		Get Started
+	</a>
+</div>

--- a/handbook/src/routes/v1000.3.2/batch/+page.md
+++ b/handbook/src/routes/v1000.3.2/batch/+page.md
@@ -1,0 +1,135 @@
+---
+title: Batch
+description: Group multiple signal updates into a single effect cycle
+---
+
+## API
+
+```typescript
+function batch<T>(fn: () => T): T
+```
+
+Executes `fn`, deferring all effect execution until `fn` completes. Returns the return value of `fn`.
+
+## Why batch
+
+Without batching, each `.set()` immediately triggers dependent effects:
+
+```typescript
+const $first = state('Ada')
+const $last = state('Lovelace')
+
+let runs = 0
+effect(() => {
+  console.log(`${$first()} ${$last()}`)
+  runs++
+})
+// => "Ada Lovelace" (runs = 1)
+
+$first.set('Grace')
+// => "Grace Lovelace" (runs = 2)
+$last.set('Hopper')
+// => "Grace Hopper" (runs = 3)
+```
+
+With batching:
+
+```typescript
+batch(() => {
+  $first.set('Grace')
+  $last.set('Hopper')
+})
+// => "Grace Hopper" (runs = 2 — one single re-run)
+```
+
+## Return values
+
+`batch()` returns whatever its callback returns:
+
+```typescript
+const $count = state(0)
+
+const result = batch(() => {
+  $count.set(42)
+  return $count()
+})
+
+console.log(result) // => 42
+```
+
+## Nesting
+
+Batches can nest. Effects only flush at the outermost batch boundary:
+
+```typescript
+const $a = state(0)
+const $b = state(0)
+
+let runs = 0
+effect(() => {
+  $a()
+  $b()
+  runs++
+})
+// runs = 1
+
+batch(() => {
+  $a.set(1)
+  batch(() => {
+    $b.set(1)
+  })
+  // inner batch completes, but effects are still deferred
+})
+// effects flush here — runs = 2
+```
+
+## Deferred effect creation
+
+Effects created inside a `batch()` are deferred until the batch completes. This means `effect()` calls inside `batch()` don't run immediately — they are queued and executed after all state updates have been applied:
+
+```typescript
+const $count = state(0)
+
+batch(() => {
+  $count.set(10)
+
+  effect(() => {
+    console.log($count()) // does NOT run here
+  })
+
+  $count.set(20)
+})
+// effect runs now, sees $count = 20
+// => 20
+```
+
+This prevents effects from seeing intermediate states during batch execution.
+
+## Error handling
+
+If the callback throws, pending effects are cleared at the outermost batch level to prevent stale effects from running:
+
+```typescript
+const $count = state(0)
+
+effect(() => console.log($count()))
+// => 0
+
+try {
+  batch(() => {
+    $count.set(999)
+    throw new Error('abort')
+  })
+} catch {
+  // pending effects are cleared
+}
+
+// The signal still holds 999, but the effect did not run for it
+console.log($count()) // => 999
+```
+
+## When to batch
+
+Batch when you update multiple signals that feed the same effects. Bulk operations over data, or initialization sequences where intermediate states are meaningless, are good candidates.
+
+A single `.set()` call has no benefit from batching. And because `batch()` is synchronous, `await` inside the callback ends the batch context at the first yield point. Async work belongs outside the batch.

--- a/handbook/src/routes/v1000.3.2/derive/+page.md
+++ b/handbook/src/routes/v1000.3.2/derive/+page.md
@@ -1,0 +1,129 @@
+---
+title: Derive
+description: Read-only computed signals that track their own dependencies
+---
+
+## API
+
+```typescript
+function derive<T>(computeFn: () => T): ReadOnlyState<T>
+```
+
+Returns a `ReadOnlyState<T>` computed from `computeFn`. Recomputes when any signal read inside `computeFn` changes.
+
+## Basic usage
+
+```typescript
+import { state, derive } from '@nerdalytics/beacon'
+
+const $price = state(100)
+const $quantity = state(2)
+const $total = derive(() => $price() * $quantity())
+
+console.log($total()) // => 200
+
+$quantity.set(5)
+console.log($total()) // => 500
+```
+
+## Read-only
+
+`derive()` returns `ReadOnlyState<T>`. There is no `.set()` or `.update()` — the value is controlled entirely by its computation function:
+
+```typescript
+const $count = state(0)
+const $doubled = derive(() => $count() * 2)
+
+$doubled()       // => 0 (reading works)
+$doubled.set(10) // TypeError — .set() does not exist on ReadOnlyState
+```
+
+This is a change from v1.0.0, where `derived()` returned a full `Signal<T>` with write methods.
+
+## Lazy initialization
+
+`derive()` is lazy-initialized. The computation function does not run until the derived value is first read or a dependency triggers an update:
+
+```typescript
+let computed = false
+const $count = state(0)
+
+const $doubled = derive(() => {
+  computed = true
+  return $count() * 2
+})
+
+console.log(computed) // => false (not yet computed)
+console.log($doubled()) // => 0
+console.log(computed) // => true (computed on first read)
+```
+
+## Same-value optimization
+
+Derived values use `Object.is()` to compare the previous and new computed values. If the result hasn't changed, downstream effects are not notified:
+
+```typescript
+const $items = state([1, 2, 3])
+const $count = derive(() => $items().length)
+
+let runs = 0
+effect(() => {
+  $count()
+  runs++
+})
+// runs = 1
+
+$items.set([4, 5, 6]) // different items, same length
+// runs = 1 (count didn't change, effect not re-run)
+
+$items.set([1, 2])
+// runs = 2 (count changed)
+```
+
+## Chaining derived values
+
+Derived values compose. Each one tracks its own dependencies independently:
+
+```typescript
+const $items = state([10, 20, 30])
+const $count = derive(() => $items().length)
+const $sum = derive(() => $items().reduce((a, b) => a + b, 0))
+const $average = derive(() => $count() > 0 ? $sum() / $count() : 0)
+
+console.log($average()) // => 20
+
+$items.set([10, 20, 30, 40])
+console.log($average()) // => 25
+```
+
+## Reading vs subscribing
+
+Reading a derived value inside an `effect()` creates a dependency, like any other signal:
+
+```typescript
+const $count = state(0)
+const $doubled = derive(() => $count() * 2)
+
+effect(() => {
+  console.log($doubled()) // subscribes to $doubled
+})
+
+$count.set(5)
+// => 10 (effect re-runs because $doubled changed)
+```
+
+Reading outside of an effect just returns the current value without tracking.
+
+## Derive vs effect
+
+Use `derive()` when you need a **value**. Use `effect()` when you need a **side effect**.
+
+```typescript
+// Good: derive produces a value
+const $fullName = derive(() => `${$first()} ${$last()}`)
+
+// Good: effect performs a side effect
+effect(() => {
+  console.log(`Name changed to ${$fullName()}`)
+})
+```

--- a/handbook/src/routes/v1000.3.2/effects/+page.md
+++ b/handbook/src/routes/v1000.3.2/effects/+page.md
@@ -1,0 +1,148 @@
+---
+title: Effects
+description: Side effects with automatic dependency tracking
+---
+
+## API
+
+```typescript
+function effect(fn: () => void): Unsubscribe
+```
+
+Runs `fn` immediately, tracks which signals it reads, and re-runs `fn` when any of those signals change. Returns an `Unsubscribe` function.
+
+`Unsubscribe` is a named export — you can import it for explicit typing:
+
+```typescript
+import { type Unsubscribe, state, effect } from '@nerdalytics/beacon'
+
+const $count = state(0)
+const unsubscribe: Unsubscribe = effect(() => {
+  console.log($count())
+})
+```
+
+## Basic usage
+
+```typescript
+import { state, effect } from '@nerdalytics/beacon'
+
+const $count = state(0)
+
+const unsubscribe = effect(() => {
+  console.log(`Count: ${$count()}`)
+})
+// => "Count: 0" (immediate)
+
+$count.set(1)
+// => "Count: 1"
+
+$count.set(2)
+// => "Count: 2"
+```
+
+## Automatic dependency tracking
+
+Dependencies are discovered by running the function. Whatever signals you call inside `fn`, those become dependencies:
+
+```typescript
+const $a = state(1)
+const $b = state(2)
+
+effect(() => {
+  console.log($a() + $b())
+})
+// Depends on both $a and $b
+```
+
+If the set of signals read changes between runs, dependencies update automatically:
+
+```typescript
+const $flag = state(true)
+const $a = state('A')
+const $b = state('B')
+
+effect(() => {
+  if ($flag()) {
+    console.log($a())
+  } else {
+    console.log($b())
+  }
+})
+// Initially depends on $flag and $a
+
+$flag.set(false)
+// Now depends on $flag and $b — $a is no longer a dependency
+```
+
+## Cleanup on re-run
+
+Before each re-run, Beacon removes the effect from all its dependency sets and re-discovers them during execution. This prevents stale dependencies from accumulating.
+
+## Unsubscribing
+
+The function returned by `effect()` stops the effect and removes it from all dependency sets:
+
+```typescript
+const $count = state(0)
+
+const unsubscribe = effect(() => {
+  console.log($count())
+})
+// => 0
+
+unsubscribe()
+
+$count.set(1)
+// (nothing — effect is disposed)
+```
+
+Always unsubscribe effects when they are no longer needed to prevent memory leaks.
+
+## Re-entrance prevention
+
+If an effect is already running, Beacon skips re-entry rather than allowing recursive execution. This prevents stack overflows in scenarios where an effect indirectly triggers itself through intermediate state changes.
+
+## Infinite loop detection
+
+An effect that writes to a state it depends on throws an error:
+
+```typescript
+const $count = state(0)
+
+effect(() => {
+  const v = $count()
+  $count.set(v + 1) // throws: "Infinite loop detected: effect() cannot update a state() it depends on!"
+})
+```
+
+In v1.0.0 this pattern looped until the queue drained. In v1000.0.0 it throws immediately.
+
+## Parent-child effect tracking
+
+Nested effects are tracked hierarchically. When a parent effect is cleaned up, its child effects are also disposed:
+
+```typescript
+const $a = state(0)
+const $b = state(0)
+
+const unsubscribe = effect(() => {
+  console.log('Outer:', $a())
+
+  effect(() => {
+    console.log('Inner:', $b())
+  })
+})
+
+// Disposing the outer effect also disposes the inner effect
+unsubscribe()
+
+$b.set(1)
+// (nothing — inner effect was cleaned up with its parent)
+```
+
+In v1.0.0, nested effects accumulated duplicates on each parent re-run.
+
+## Effect execution order
+
+When multiple effects depend on the same signal, they execute in the order they were registered. Effects scheduled during a batch are collected and run once when the batch completes.

--- a/handbook/src/routes/v1000.3.2/installation/+page.md
+++ b/handbook/src/routes/v1000.3.2/installation/+page.md
@@ -1,0 +1,56 @@
+---
+title: Installation
+description: Install Beacon and set up your project
+---
+
+## Requirements
+
+- Node.js 20.0.0 or later (LTS v20 or v22)
+- TypeScript 5.x recommended, not required
+
+## Install
+
+```bash
+npm install @nerdalytics/beacon --save-exact
+```
+
+## Project setup
+
+Beacon ships as ESM. Set `"type": "module"` in your `package.json`:
+
+```json
+{
+  "type": "module"
+}
+```
+
+For TypeScript, these compiler options work well with Beacon:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "verbatimModuleSyntax": true
+  }
+}
+```
+
+## Verify
+
+```typescript
+import { state, derive, effect } from '@nerdalytics/beacon'
+
+const $count = state(0)
+const $doubled = derive(() => $count() * 2)
+
+effect(() => console.log($doubled()))
+// => 0
+
+$count.set(1)
+// => 2
+```
+
+If you see `0` then `2`, the installation is correct.

--- a/handbook/src/routes/v1000.3.2/introduction/+page.md
+++ b/handbook/src/routes/v1000.3.2/introduction/+page.md
@@ -1,0 +1,33 @@
+---
+title: Introduction
+description: What Beacon v1000.3.1 is and what changed from v1000.3.0
+---
+
+Beacon is a reactive state library for Node.js. It tracks which values each function reads and re-runs that function when those values change.
+
+Eight functions make up the API:
+
+- **`state(initialValue, equalityFn?)`** creates a readable and writable signal
+- **`derive(fn)`** computes a read-only value from other signals
+- **`effect(fn)`** runs a function when its dependencies change
+- **`batch(fn)`** groups updates so effects run once
+- **`select(source, selectorFn, equalityFn?)`** subscribes to a computed slice of state
+- **`lens(source, accessor)`** two-way binding to a nested property
+- **`readonlyState(state)`** hides the write methods on a state
+- **`protectedState(initialValue, equalityFn?)`** separates read and write into a tuple
+
+When you read a signal inside an effect, Beacon records the dependency. When the signal changes, the effect re-runs. No manual subscriptions, event names, or wiring.
+
+## Changes from v1000.3.0
+
+v1000.3.1 reduces allocations in three hot paths: `protectedState` reader caching, `stateTracking` Set reuse on effect re-runs, and index-based iteration in `lens` path updates. Nested effect disposal now fully cleans up child references. No API or behavioral changes. ~480 LOC. See the [migration guide](/v1000.3.1/migration).
+
+## Constraints
+
+Single TypeScript file, ~480 lines, zero dependencies. Node.js 20+, full type inference. Internals are standalone functions with module-level tracking state.
+
+## Use cases
+
+Configuration objects that trigger side effects on change. In-memory caches that recompute derived data when inputs update. Event-driven pipelines where state changes propagate through a dependency graph. `select()` avoids unrelated recomputation on large state objects. `lens()` gives subsystems two-way ownership of a slice of shared state.
+
+Beacon is not a frontend framework. No DOM bindings, no component model. It manages plain JavaScript values on the server.

--- a/handbook/src/routes/v1000.3.2/lens/+page.md
+++ b/handbook/src/routes/v1000.3.2/lens/+page.md
@@ -105,6 +105,22 @@ $theme.set('dark')
 console.log($config().theme) // => "dark"
 ```
 
+## Path safety
+
+`lens()` rejects three property names: `__proto__`, `constructor`, and `prototype`. If the accessor traverses any of these keys, the lens silently ignores writes. Reads continue to work.
+
+This is a defense-in-depth measure against prototype pollution. Modern JavaScript engines handle the specific code path safely today, but the guard removes the dependency on engine behavior. The denylist is checked once during path extraction, not on every read or write.
+
+```typescript
+const $user = state({ name: 'Alice' })
+
+// This lens can read but will not write back
+const $noop = lens($user, (u) => (u as any).__proto__)
+$noop.set({ polluted: true })
+
+console.log($user()) // => { name: 'Alice' } — unchanged
+```
+
 ## Reactivity
 
 Like any `State<K>`, a lens works with effects and derive:

--- a/handbook/src/routes/v1000.3.2/lens/+page.md
+++ b/handbook/src/routes/v1000.3.2/lens/+page.md
@@ -1,0 +1,126 @@
+---
+title: Lens
+description: Two-way binding to a nested property of state
+---
+
+## API
+
+```typescript
+function lens<T, K>(
+  source: State<T>,
+  accessor: (state: T) => K
+): State<K>
+```
+
+Returns a writable `State<K>` focused on a nested property of `source`. Reads return the value at that path. Writes immutably update the source at that path.
+
+## Basic usage
+
+```typescript
+import { state, lens, effect } from '@nerdalytics/beacon'
+
+const $config = state({
+  server: { host: 'localhost', port: 3000 }
+})
+
+const $host = lens($config, (c) => c.server.host)
+
+console.log($host()) // => "localhost"
+
+$host.set('0.0.0.0')
+console.log($config().server.host) // => "0.0.0.0"
+
+effect(() => console.log($host()))
+// => "0.0.0.0"
+
+$host.set('127.0.0.1')
+// => "127.0.0.1"
+```
+
+## How it differs from select
+
+`select()` returns a read-only `ReadOnlyState<R>`. It subscribes to a slice but cannot write back.
+
+`lens()` returns a writable `State<K>`. It subscribes to a slice and can write back to the source, maintaining immutability throughout the object tree.
+
+| | `select()` | `lens()` |
+|---|---|---|
+| Return type | `ReadOnlyState<R>` | `State<K>` |
+| Read | Yes | Yes |
+| Write | No | Yes |
+| Use case | Derived slices, computed projections | Two-way bindings to nested properties |
+
+Use `select()` when you only need to read a slice. Use `lens()` when you need to read and write to a nested property.
+
+## Deep nesting
+
+The accessor can reach arbitrarily deep into the object tree:
+
+```typescript
+const $app = state({
+  ui: {
+    panels: {
+      sidebar: { collapsed: false, width: 250 }
+    }
+  }
+})
+
+const $collapsed = lens($app, (a) => a.ui.panels.sidebar.collapsed)
+
+$collapsed.set(true)
+console.log($app().ui.panels.sidebar.collapsed) // => true
+```
+
+Writes rebuild the object tree immutably from the leaf to the root. The source reference changes, triggering effects that depend on it or on intermediate slices.
+
+## Array index support
+
+The accessor can index into arrays:
+
+```typescript
+const $list = state({ items: ['a', 'b', 'c'] })
+
+const $second = lens($list, (l) => l.items[1])
+
+console.log($second()) // => "b"
+
+$second.set('B')
+console.log($list().items) // => ['a', 'B', 'c']
+```
+
+## Circular update prevention
+
+`lens()` uses an `isUpdating` flag to break the source↔lens feedback loop. When the lens writes to the source, the sync effect is suppressed. When the source changes externally, the lens reflects the new value without writing back.
+
+```typescript
+const $config = state({ theme: 'dark' })
+const $theme = lens($config, (c) => c.theme)
+
+// External update to source — lens reflects it
+$config.set({ theme: 'light' })
+console.log($theme()) // => "light"
+
+// Lens update — source reflects it, no loop
+$theme.set('dark')
+console.log($config().theme) // => "dark"
+```
+
+## Reactivity
+
+Like any `State<K>`, a lens works with effects and derive:
+
+```typescript
+const $settings = state({
+  notifications: { email: true, push: false }
+})
+
+const $push = lens($settings, (s) => s.notifications.push)
+
+effect(() => {
+  console.log(`Push notifications: ${$push()}`)
+})
+// => "Push notifications: false"
+
+$push.set(true)
+// => "Push notifications: true"
+```

--- a/handbook/src/routes/v1000.3.2/links/+page.md
+++ b/handbook/src/routes/v1000.3.2/links/+page.md
@@ -1,0 +1,13 @@
+---
+title: Resources
+description: Source code, packages, and related work
+---
+
+## Source
+
+- [GitHub](https://github.com/nerdalytics/beacon)
+- [npm](https://www.npmjs.com/package/@nerdalytics/beacon)
+
+## Related
+
+- [TC39 Signals Proposal](https://github.com/tc39/proposal-signals) — the standards proposal that informed Beacon's API surface

--- a/handbook/src/routes/v1000.3.2/llms/+page.md
+++ b/handbook/src/routes/v1000.3.2/llms/+page.md
@@ -1,0 +1,41 @@
+---
+title: LLM Documentation
+description: Plain-text endpoints for referencing Beacon docs in LLM conversations
+---
+
+## Overview
+
+The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
+
+## Endpoints
+
+| URL | Content |
+|---|---|
+| `/llms.txt` | Index of all available versions |
+| `/{version}/llms.txt` | Page listing for a specific version |
+| `/{version}/llms-full.txt` | All pages concatenated into one document |
+| `/{version}/{page}.md` | Single page as raw Markdown |
+
+Replace `{version}` with a version number (e.g. `v1000.3.1`) or `latest`.
+
+## Examples
+
+Full documentation context:
+
+```
+Read https://beacon.nerdalytics.dev/latest/llms-full.txt and explain how state() works.
+```
+
+Single page reference:
+
+```
+Read https://beacon.nerdalytics.dev/latest/state.md and show me how to use nested reactivity.
+```
+
+## Tool integration
+
+These URLs work anywhere an LLM can fetch a resource:
+
+- **Claude Code** / **ChatGPT** — paste the URL into your prompt
+- **Cursor** / **Windsurf** — add as a doc reference
+- **Custom agents** — fetch `/{version}/llms-full.txt` as system context

--- a/handbook/src/routes/v1000.3.2/migration/+page.md
+++ b/handbook/src/routes/v1000.3.2/migration/+page.md
@@ -1,0 +1,30 @@
+---
+title: v1000.3.0 → v1000.3.1
+description: Migrating from Beacon v1000.3.0 to v1000.3.1
+---
+
+No API changes. No breaking changes. Drop-in upgrade.
+
+This release reduces allocations in three hot paths. The public interface, behavior, and type signatures are identical to v1000.3.0.
+
+## What changed
+
+`protectedState` previously created a new readonly wrapper function on every read. It now caches the wrapper once at construction time.
+
+Effects that re-run used to allocate a fresh `Set` for dependency tracking each cycle. The existing Set is now cleared and reused.
+
+`lens` path updates called `Array.slice()` at each recursion level when writing to nested properties, allocating O(n) intermediate arrays on a path of depth n. These now use index-based iteration with zero intermediate allocations.
+
+## Internal
+
+The unsubscribe path for nested effects now fully cleans up child references in `activeSubscribers`, `stateTracking`, and `parentSubscriber`. Previously, only the dependency subscriptions were removed, leaving unreachable entries in those WeakMaps until garbage collection. This was not observable in behavior or tests, but it delayed memory reclamation in long-lived applications with frequent effect creation and disposal.
+
+Several internal simplifications: closure variables replace container objects in `derive`, `select`, and `lens`; a shared `getOrCreate` helper replaces four duplicated WeakMap lookup blocks; `updateArrayPath` and `updateObjectPath` are inlined into `setValueAtPath`.
+
+## Upgrade
+
+```bash
+npm install @nerdalytics/beacon@1000.3.1 --save-exact
+```
+
+No code changes required. Existing tests pass without modification.

--- a/handbook/src/routes/v1000.3.2/migration/+page.md
+++ b/handbook/src/routes/v1000.3.2/migration/+page.md
@@ -1,30 +1,28 @@
 ---
-title: v1000.3.0 → v1000.3.1
-description: Migrating from Beacon v1000.3.0 to v1000.3.1
+title: v1000.3.1 → v1000.3.2
+description: Migrating from Beacon v1000.3.1 to v1000.3.2
 ---
 
 No API changes. No breaking changes. Drop-in upgrade.
 
-This release reduces allocations in three hot paths. The public interface, behavior, and type signatures are identical to v1000.3.0.
+This release adds a proto-key denylist to lens path extraction. The public interface, behavior, and type signatures are identical to v1000.3.1.
 
 ## What changed
 
-`protectedState` previously created a new readonly wrapper function on every read. It now caches the wrapper once at construction time.
+`lens()` now rejects `__proto__`, `constructor`, and `prototype` as path segments. If an accessor traverses one of these keys, the lens treats the path as invalid and silently ignores writes. Reads still reflect the source value.
 
-Effects that re-run used to allocate a fresh `Set` for dependency tracking each cycle. The existing Set is now cleared and reused.
+The guard runs once during path extraction via a `tainted` flag in the Proxy trap. When a dangerous key appears at any depth in the path, the entire path is discarded, not just the offending segment. This prevents orphaned child segments from writing to unintended properties.
 
-`lens` path updates called `Array.slice()` at each recursion level when writing to nested properties, allocating O(n) intermediate arrays on a path of depth n. These now use index-based iteration with zero intermediate allocations.
+`lensSet` checks for an empty path and returns early, making the write a no-op. `lensUpdate` delegates to `lensSet`, so both write methods are covered.
 
-## Internal
+## Why
 
-The unsubscribe path for nested effects now fully cleans up child references in `activeSubscribers`, `stateTracking`, and `parentSubscriber`. Previously, only the dependency subscriptions were removed, leaving unreachable entries in those WeakMaps until garbage collection. This was not observable in behavior or tests, but it delayed memory reclamation in long-lived applications with frequent effect creation and disposal.
-
-Several internal simplifications: closure variables replace container objects in `derive`, `select`, and `lens`; a shared `getOrCreate` helper replaces four duplicated WeakMap lookup blocks; `updateArrayPath` and `updateObjectPath` are inlined into `setValueAtPath`.
+Prototype pollution through `constructor.prototype` is a known attack vector with multiple CVEs in libraries like lodash, protobuf.js, and tree-kit. Beacon's spread-then-assign pattern in `setValueAtPath` is safe on current V8, but that safety comes from engine behavior, not explicit guards. The denylist makes the safety explicit.
 
 ## Upgrade
 
 ```bash
-npm install @nerdalytics/beacon@1000.3.1 --save-exact
+npm install @nerdalytics/beacon@1000.3.2 --save-exact
 ```
 
 No code changes required. Existing tests pass without modification.

--- a/handbook/src/routes/v1000.3.2/quick-start/+page.md
+++ b/handbook/src/routes/v1000.3.2/quick-start/+page.md
@@ -1,0 +1,140 @@
+---
+title: Quick Start
+description: Signals, derived values, effects, batching, and select in five minutes
+---
+
+This page walks through Beacon's core primitives with runnable examples.
+
+## Create a signal
+
+```typescript
+import { state } from '@nerdalytics/beacon'
+
+const $count = state(0)
+
+// Read the value by calling it
+console.log($count()) // => 0
+
+// Write with .set()
+$count.set(5)
+console.log($count()) // => 5
+
+// Update with a function
+$count.update((n) => n + 1)
+console.log($count()) // => 6
+```
+
+A signal is a function that returns its current value when called. Use `.set()` to replace the value or `.update()` to transform it.
+
+## Derive a value
+
+```typescript
+import { state, derive } from '@nerdalytics/beacon'
+
+const $count = state(0)
+const $doubled = derive(() => $count() * 2)
+
+console.log($doubled()) // => 0
+
+$count.set(3)
+console.log($doubled()) // => 6
+```
+
+`derive()` creates a read-only signal that recomputes whenever its dependencies change. It returns a `ReadOnlyState<T>` — you can read it but not write to it.
+
+## React to changes
+
+```typescript
+import { state, effect } from '@nerdalytics/beacon'
+
+const $name = state('world')
+
+const unsubscribe = effect(() => {
+  console.log(`Hello, ${$name()}!`)
+})
+// => "Hello, world!" (runs immediately)
+
+$name.set('Beacon')
+// => "Hello, Beacon!"
+
+// Stop the effect
+unsubscribe()
+$name.set('ignored')
+// (nothing printed)
+```
+
+`effect()` runs its callback immediately, tracks which signals were read, and re-runs when any of them change. It returns an unsubscribe function that stops the effect and cleans up all subscriptions.
+
+## Batch updates
+
+```typescript
+import { state, derive, effect, batch } from '@nerdalytics/beacon'
+
+const $first = state('Ada')
+const $last = state('Lovelace')
+const $full = derive(() => `${$first()} ${$last()}`)
+
+let runs = 0
+effect(() => {
+  runs++
+  console.log($full())
+})
+// => "Ada Lovelace" (runs = 1)
+
+batch(() => {
+  $first.set('Grace')
+  $last.set('Hopper')
+})
+// => "Grace Hopper" (runs = 2, not 3)
+```
+
+Without `batch()`, each `.set()` would trigger the effect separately. With `batch()`, effects run once after all updates complete.
+
+## Select a slice
+
+```typescript
+import { state, select, effect } from '@nerdalytics/beacon'
+
+const $user = state({ name: 'Ada', role: 'dev', loginCount: 0 })
+
+const $name = select($user, (u) => u.name)
+
+let runs = 0
+effect(() => {
+  console.log($name())
+  runs++
+})
+// => "Ada" (runs = 1)
+
+// Update an unrelated property — effect does NOT re-run
+$user.update((u) => ({ ...u, loginCount: u.loginCount + 1 }))
+// runs = 1 (still)
+
+// Update the selected property — effect re-runs
+$user.update((u) => ({ ...u, name: 'Grace' }))
+// => "Grace" (runs = 2)
+```
+
+`select()` creates a derived signal that only updates when the selected slice changes, not when unrelated properties change.
+
+## Putting it together
+
+```typescript
+import { state, derive, effect, batch, select } from '@nerdalytics/beacon'
+
+const $config = state({ host: 'localhost', port: 3000, debug: false })
+const $host = select($config, (c) => c.host)
+const $url = derive(() => `http://${$host()}:${$config().port}`)
+
+effect(() => {
+  console.log(`Server: ${$url()}`)
+})
+// => "Server: http://localhost:3000"
+
+batch(() => {
+  $config.update((c) => ({ ...c, host: '0.0.0.0', port: 8080 }))
+})
+// => "Server: http://0.0.0.0:8080"
+```
+
+Seven functions, no configuration, no setup.

--- a/handbook/src/routes/v1000.3.2/select/+page.md
+++ b/handbook/src/routes/v1000.3.2/select/+page.md
@@ -1,0 +1,120 @@
+---
+title: Select
+description: Subscribe to a computed slice of state
+---
+
+## API
+
+```typescript
+function select<T, R>(
+  source: ReadOnlyState<T>,
+  selectorFn: (state: T) => R,
+  equalityFn?: (a: R, b: R) => boolean
+): ReadOnlyState<R>
+```
+
+Returns a `ReadOnlyState<R>` holding `selectorFn(source())`. The signal only notifies downstream when the selected value changes, not when unrelated parts of the source change.
+
+## Basic usage
+
+```typescript
+import { state, select, effect } from '@nerdalytics/beacon'
+
+const $user = state({ name: 'Ada', role: 'dev', loginCount: 0 })
+
+const $name = select($user, (u) => u.name)
+
+effect(() => {
+  console.log(`Name: ${$name()}`)
+})
+// => "Name: Ada"
+
+// Updating an unrelated property — effect does NOT re-run
+$user.update((u) => ({ ...u, loginCount: u.loginCount + 1 }))
+
+// Updating the selected property — effect re-runs
+$user.update((u) => ({ ...u, name: 'Grace' }))
+// => "Name: Grace"
+```
+
+## Why select
+
+Without `select()`, an effect that reads any property of a state object re-runs whenever the entire object changes:
+
+```typescript
+const $user = state({ name: 'Ada', loginCount: 0 })
+
+// This runs on EVERY $user change, even if name didn't change
+effect(() => {
+  console.log($user().name)
+})
+
+$user.update((u) => ({ ...u, loginCount: u.loginCount + 1 }))
+// Effect re-runs even though name is still 'Ada'
+```
+
+`select()` compares the selected slice before and after each source update. If the slice hasn't changed, downstream effects are not notified.
+
+## Custom equality
+
+By default, `select()` uses `Object.is()` to compare the previous and new selected values. You can provide a custom equality function for cases where reference equality is too strict:
+
+```typescript
+const $data = state({ items: [1, 2, 3], meta: { page: 1 } })
+
+// Deep equality for arrays
+const $items = select(
+  $data,
+  (d) => d.items,
+  (a, b) => a.length === b.length && a.every((v, i) => v === b[i])
+)
+
+effect(() => {
+  console.log('Items:', $items())
+})
+// => "Items: [1, 2, 3]"
+
+// New array with same contents — effect does NOT re-run
+$data.update((d) => ({ ...d, items: [1, 2, 3] }))
+
+// Different contents — effect re-runs
+$data.update((d) => ({ ...d, items: [1, 2, 3, 4] }))
+// => "Items: [1, 2, 3, 4]"
+```
+
+## Composing selectors
+
+`select()` returns a `ReadOnlyState<R>`, so it works anywhere a signal is expected — inside effects, derived values, or even as the source for another `select()`:
+
+```typescript
+const $app = state({
+  user: { name: 'Ada', prefs: { theme: 'dark' } },
+  data: []
+})
+
+const $user = select($app, (a) => a.user)
+const $theme = select($app, (a) => a.user.prefs.theme)
+
+effect(() => {
+  console.log(`Theme: ${$theme()}`)
+})
+// Only re-runs when theme actually changes
+```
+
+## Select vs derive
+
+Both produce `ReadOnlyState`. The difference is notification:
+
+- `derive()` notifies downstream whenever any dependency changes and the result differs
+- `select()` only notifies when the selected slice differs, even if the source object changed
+
+For large state objects where you care about one property, `select()` avoids the recomputation overhead `derive()` would cause.
+
+## Select vs lens
+
+`select()` and `lens()` both subscribe to a nested property of state. The difference is writability:
+
+- `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
+- `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
+
+Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.3.1/lens) when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.3.2/state/+page.md
+++ b/handbook/src/routes/v1000.3.2/state/+page.md
@@ -1,0 +1,203 @@
+---
+title: State
+description: Reactive signals with automatic dependency tracking
+---
+
+## API
+
+```typescript
+function state<T>(initialValue: T, equalityFn?: (a: T, b: T) => boolean): State<T>
+```
+
+Returns a `State<T>` wrapping the initial value. A state is a callable function with `.set()` and `.update()` methods. The optional `equalityFn` replaces `Object.is` for the same-value check — see [Custom equality](#custom-equality).
+
+## Type interfaces
+
+```typescript
+type ReadOnlyState<T> = () => T
+
+interface WriteableState<T> {
+  set(value: T): void
+  update(fn: (current: T) => T): void
+}
+
+type State<T> = ReadOnlyState<T> & WriteableState<T>
+
+type Unsubscribe = () => void
+```
+
+`State<T>` combines both read and write capabilities. `ReadOnlyState<T>` is callable and read-only — returned by `derive()` and `select()`. `WriteableState<T>` exposes `.set()` and `.update()`. `Unsubscribe` is the return type of `effect()` — call it to dispose the effect and remove it from all dependency sets.
+
+All four types are `export type` only. Import them with `import type`:
+
+```typescript
+import type { State, ReadOnlyState, WriteableState, Unsubscribe } from '@nerdalytics/beacon'
+// or inline
+import { state, type State } from '@nerdalytics/beacon'
+```
+
+## Creating signals
+
+```typescript
+import { state } from '@nerdalytics/beacon'
+
+const $count = state(0)
+const $name = state('Beacon')
+const $items = state<string[]>([])
+const $config = state({ host: 'localhost', port: 3000 })
+```
+
+Signals accept any type: primitives, arrays, objects, `null`, `undefined`.
+
+## Reading
+
+```typescript
+const $count = state(0)
+
+// Direct read
+console.log($count()) // => 0
+
+// Inside an effect — creates a dependency
+effect(() => {
+  console.log($count()) // tracked
+})
+```
+
+Reading inside an `effect()` or `derive()` callback registers a dependency. Reading outside of these contexts returns the value without tracking.
+
+## Writing
+
+### `.set(value)`
+
+Replaces the current value:
+
+```typescript
+const $count = state(0)
+$count.set(5)
+console.log($count()) // => 5
+```
+
+### `.update(fn)`
+
+Transforms the value using the current value:
+
+```typescript
+const $count = state(0)
+$count.update((n) => n + 1)
+console.log($count()) // => 1
+```
+
+Useful when the new value depends on the old one.
+
+## Same-value optimization
+
+Beacon uses `Object.is()` to compare old and new values. If the value hasn't changed, subscribers are not notified:
+
+```typescript
+const $count = state(0)
+let runs = 0
+
+effect(() => {
+  $count()
+  runs++
+})
+// runs = 1 (initial run)
+
+$count.set(0) // same value
+// runs = 1 (no re-run)
+
+$count.set(1) // different value
+// runs = 2
+```
+
+This means reference equality matters for objects and arrays. Setting the same object reference won't trigger updates:
+
+```typescript
+const $list = state([1, 2, 3])
+const arr = $list()
+arr.push(4)
+$list.set(arr) // same reference — no update
+
+$list.set([...arr]) // new reference — triggers update
+```
+
+## Custom equality
+
+By default, `state()` uses `Object.is` to decide whether a `.set()` call should notify subscribers. You can override this by passing a custom equality function as the second argument:
+
+```typescript
+function state<T>(initialValue: T, equalityFn?: (a: T, b: T) => boolean): State<T>
+```
+
+The equality function receives the current value and the incoming value. Return `true` to skip notification (values are equal), `false` to notify.
+
+```typescript
+import { state, effect } from '@nerdalytics/beacon'
+
+const $user = state(
+  { name: 'Ada', age: 36 },
+  (a, b) => a.name === b.name && a.age === b.age
+)
+
+let runs = 0
+effect(() => {
+  $user()
+  runs++
+})
+// runs = 1
+
+$user.set({ name: 'Ada', age: 36 }) // structurally equal — no notification
+// runs = 1
+
+$user.set({ name: 'Grace', age: 36 }) // different — notifies
+// runs = 2
+```
+
+`protectedState()` accepts the same optional second argument:
+
+```typescript
+import { protectedState } from '@nerdalytics/beacon'
+
+const [$read, $write] = protectedState(
+  { name: 'Ada', age: 36 },
+  (a, b) => a.name === b.name && a.age === b.age
+)
+```
+
+If omitted, both functions fall back to `Object.is`, preserving the same behavior as previous versions.
+
+## Working with objects
+
+Since signals use value-level (not property-level) tracking, you must replace the entire object to trigger updates:
+
+```typescript
+const $user = state({ name: 'Ada', age: 36 })
+
+// This does NOT trigger updates:
+$user().name = 'Grace'
+
+// This does:
+$user.set({ ...$user(), name: 'Grace' })
+
+// Or use .update():
+$user.update((u) => ({ ...u, name: 'Grace' }))
+```
+
+For property-level subscriptions, use `select()` to react only when a specific property changes.
+
+## Working with arrays
+
+Same principle — create a new array reference:
+
+```typescript
+const $items = state<string[]>([])
+
+// Add an item
+$items.update((items) => [...items, 'new item'])
+
+// Remove an item
+$items.update((items) => items.filter((i) => i !== 'new item'))
+
+// Replace at index
+$items.update((items) => items.map((item, i) => i === 0 ? 'replaced' : item))
+```


### PR DESCRIPTION
## Summary

- Refactors `navigation.ts` from ~1000 lines of copy-paste version blocks to a config-driven `buildNav` factory (~130 lines)
- Adds v1000.3.2 handbook route with enhanced lens page (path safety section) and migration page
- Updates `/latest` to mirror v1000.3.2 content
- Sets v1000.3.2 as the current version in `versions.ts`

Closes #83