### PR TITLE
refactor(core): remove dead STATE_ID symbol and fix Biome config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
 	"assist": {
 		"actions": {
 			"source": {
@@ -19,7 +19,10 @@
 			"!**/tests/template.test.ts",
 			"!**/dist/**/*",
 			"!**/temp/**/*",
-			"!**/node_modules/**/*"
+			"!**/node_modules/**/*",
+			"!.claude/**/*",
+			"!**/.svelte-kit/**/*",
+			"!**/handbook/build/**/*"
 		]
 	},
 	"formatter": {
@@ -50,8 +53,8 @@
 			"trailingCommas": "none"
 		},
 		"parser": {
-			"allowComments": false,
-			"allowTrailingCommas": false
+			"allowComments": true,
+			"allowTrailingCommas": true
 		}
 	},
 	"linter": {
@@ -62,6 +65,12 @@
 			},
 			"complexity": {
 				"noBannedTypes": "error",
+				"noExcessiveCognitiveComplexity": {
+					"level": "error",
+					"options": {
+						"maxAllowedComplexity": 15
+					}
+				},
 				"useLiteralKeys": "error"
 			},
 			"correctness": {
@@ -75,7 +84,8 @@
 				"useExplicitType": "error"
 			},
 			"performance": {
-				"noAccumulatingSpread": "error"
+				"noAccumulatingSpread": "error",
+				"useTopLevelRegex": "error"
 			},
 			"recommended": true,
 			"security": {

--- a/handbook/src/lib/navigation.ts
+++ b/handbook/src/lib/navigation.ts
@@ -1,5 +1,7 @@
 import { base } from '$app/paths'
 
+const VERSION_PREFIX_RE = /^(\/v[\d.]+)/
+
 export interface NavItem {
 	href: string
 	title: string
@@ -219,7 +221,7 @@ export const navigation: Record<string, NavGroup[]> = Object.fromEntries(
 export function getVersionPrefix(pathname: string): string | undefined {
 	const path = base && pathname.startsWith(base) ? pathname.slice(base.length) : pathname
 	if (path === '/latest' || path.startsWith('/latest/')) return '/latest'
-	const match = path.match(/^(\/v[\d.]+)/)
+	const match = path.match(VERSION_PREFIX_RE)
 	return match?.[1]
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,7 @@ interface WriteableState<T> {
 	update(fn: (value: T) => T): void
 }
 
-// Special symbol used for internal tracking
-const STATE_ID: unique symbol = Symbol('STATE_ID')
-
-type State<T> = ReadOnlyState<T> &
-	WriteableState<T> & {
-		[STATE_ID]?: symbol
-	}
+type State<T> = ReadOnlyState<T> & WriteableState<T>
 
 // Module-level reactive state
 let currentSubscriber: Subscriber | null = null
@@ -151,7 +145,6 @@ const createState = <T>(initialValue: T, equalityFn: (a: T, b: T) => boolean = O
 		get.set(fn(value))
 	}
 
-	get[STATE_ID] = stateId
 	return get as State<T>
 }
 
@@ -341,46 +334,37 @@ const setValueAtPath = <V, O>(obj: O, pathSegments: (string | number)[], depth: 
 		return obj
 	}
 
-	if (Array.isArray(obj)) {
-		const index = Number(currentKey)
-
-		if (depth === pathSegments.length - 1) {
-			return updateArrayItem(obj, index, value) as unknown as O
-		}
-
-		const copy = [
-			...obj,
-		]
-		const nextDepth = depth + 1
-		const nextKey = pathSegments[nextDepth]
-
-		let nextValue = obj[index]
-		if (nextValue === undefined || nextValue === null) {
-			nextValue = nextKey === undefined ? {} : createContainer(nextKey)
-		}
-
-		copy[index] = setValueAtPath(nextValue, pathSegments, nextDepth, value)
-		return copy as unknown as O
-	}
-
-	const record = obj as Record<string | number, unknown>
+	const isArray = Array.isArray(obj)
+	const key = isArray ? Number(currentKey) : currentKey
 
 	if (depth === pathSegments.length - 1) {
-		return updateShallowProperty(record, currentKey, value) as unknown as O
+		if (isArray) {
+			return updateArrayItem(obj as unknown[], key as number, value) as unknown as O
+		}
+		return updateShallowProperty(obj as Record<string | number, unknown>, key, value) as unknown as O
 	}
 
 	const nextDepth = depth + 1
 	const nextKey = pathSegments[nextDepth]
+	const source = isArray ? (obj as unknown[])[key as number] : (obj as Record<string | number, unknown>)[key]
 
-	let currentValue = record[currentKey]
-	if (currentValue === undefined || currentValue === null) {
-		currentValue = nextKey === undefined ? {} : createContainer(nextKey)
+	let nextValue = source
+	if (nextValue === undefined || nextValue === null) {
+		nextValue = nextKey === undefined ? {} : createContainer(nextKey)
+	}
+
+	if (isArray) {
+		const copy = [
+			...(obj as unknown[]),
+		]
+		copy[key as number] = setValueAtPath(nextValue, pathSegments, nextDepth, value)
+		return copy as unknown as O
 	}
 
 	const result = {
-		...record,
+		...(obj as Record<string | number, unknown>),
 	}
-	result[currentKey] = setValueAtPath(currentValue, pathSegments, nextDepth, value)
+	result[key] = setValueAtPath(nextValue, pathSegments, nextDepth, value)
 	return result as unknown as O
 }
 


### PR DESCRIPTION
## Summary

- Remove unused `STATE_ID` symbol, its `State<T>` type property, and getter assignment
- Restructure `setValueAtPath` to unify duplicated array/object branches, bringing cognitive complexity under the configured limit
- Sync `biome.json` with installed CLI version (2.4.7), add ignore patterns for `.claude`, `.svelte-kit`, and `handbook/build`
- Hoist regex literal to module scope in handbook navigation

Closes #63

## Test plan

- [x] `npm run build` passes
- [x] `npm run check` passes (0 errors)
- [x] `npm test` — 117/117 pass