### PR TITLE
fix(handbook): replace hardcoded version strings with dynamic components

### DIFF
--- a/handbook/src/lib/components/DocLayout.svelte
+++ b/handbook/src/lib/components/DocLayout.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte'
+	import { onMount, setContext } from 'svelte'
 	import { page } from '$app/state'
 	import { addCopyButtons } from '$lib/copy-code'
 	import { getAllPages, getVersionPrefix } from '$lib/navigation'
 	import { resolveHref } from '$lib/resolve-href'
+	import { resolveVersionLabel } from '$lib/versions'
 	import TOC from './TOC.svelte'
 
 	let {
@@ -29,6 +30,15 @@
 	)
 	let prevPage = $derived(currentIndex > 0 ? allPages[currentIndex - 1] : null)
 	let nextPage = $derived(currentIndex < allPages.length - 1 ? allPages[currentIndex + 1] : null)
+
+	setContext('version', {
+		get label() {
+			return resolveVersionLabel(versionPrefix)
+		},
+		get prefix() {
+			return versionPrefix
+		},
+	})
 </script>
 
 <svelte:head>

--- a/handbook/src/lib/components/Version.svelte
+++ b/handbook/src/lib/components/Version.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { getContext } from 'svelte'
+
+	const { label } = getContext('version')
+</script>{label}

--- a/handbook/src/lib/components/VersionLink.svelte
+++ b/handbook/src/lib/components/VersionLink.svelte
@@ -4,5 +4,5 @@
 
 	const { prefix } = getContext('version')
 
-	export let path
-</script><a href={resolveHref(`${prefix}${path}`)}><slot /></a>
+	let { path, children } = $props()
+</script><a href={resolveHref(`${prefix}${path}`)}>{@render children()}</a>

--- a/handbook/src/lib/components/VersionLink.svelte
+++ b/handbook/src/lib/components/VersionLink.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { getContext } from 'svelte'
+	import { resolveHref } from '$lib/resolve-href'
+
+	const { prefix } = getContext('version')
+
+	export let path
+</script><a href={resolveHref(`${prefix}${path}`)}><slot /></a>

--- a/handbook/src/lib/versions.ts
+++ b/handbook/src/lib/versions.ts
@@ -124,3 +124,11 @@ export const versions: Version[] = [
 
 // biome-ignore lint/style/noNonNullAssertion: versions array is static and always contains a current version
 export const currentVersion: Version = versions.find((v) => v.current)!
+
+export function resolveVersionLabel(prefix: string): string {
+	if (prefix === '/latest') {
+		const current = versions.find((v) => v.current)
+		return current ? current.label : 'latest'
+	}
+	return prefix.slice(1)
+}

--- a/handbook/src/routes/latest/architecture/+page.md
+++ b/handbook/src/routes/latest/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.3.1 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.3.1 is ~480 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~480 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
 
 ## Standalone functions
 

--- a/handbook/src/routes/latest/introduction/+page.md
+++ b/handbook/src/routes/latest/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.3.2 is and what changed from v1000.3.1
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +25,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.3.1
 
-v1000.3.2 adds a proto-key denylist to `lens()` path extraction. Accessor paths that traverse `__proto__`, `constructor`, or `prototype` are silently rejected as a defense-in-depth measure against prototype pollution. No API or behavioral changes for legitimate use. See the [migration guide](/latest/migration).
+<Version /> adds a proto-key denylist to `lens()` path extraction. Accessor paths that traverse `__proto__`, `constructor`, or `prototype` are silently rejected as a defense-in-depth measure against prototype pollution. No API or behavioral changes for legitimate use. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/latest/llms/+page.md
+++ b/handbook/src/routes/latest/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `latest`) or a pinned release like `v1000.3.1`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/latest/select/+page.md
+++ b/handbook/src/routes/latest/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/latest/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1.0.0/llms/+page.md
+++ b/handbook/src/routes/v1.0.0/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1.0.0`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.0.0/architecture/+page.md
+++ b/handbook/src/routes/v1000.0.0/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.0.0 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.0.0 is ~427 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~427 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.0.0/introduction/+page.md
+++ b/handbook/src/routes/v1000.0.0/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.0.0 is and what changed from v1.0.0
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -19,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1.0.0
 
-v1000.0.0 is a complete rewrite of the library internals and API surface:
+<Version /> is a complete rewrite of the library internals and API surface:
 
 - `derived()` renamed to `derive()`, now returns `ReadOnlyState<T>` (no `.set()`/`.update()`)
 - `select()` added for property-level subscriptions on state objects
@@ -30,7 +35,7 @@ v1000.0.0 is a complete rewrite of the library internals and API surface:
 - Effects created inside `batch()` are deferred until the batch completes
 - `derive()` is lazy: it computes on first read, not on creation
 
-See the [migration guide](/v1000.0.0/migration) for the full list of breaking changes.
+See the <VersionLink path="/migration">migration guide</VersionLink> for the full list of breaking changes.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.0.0/llms/+page.md
+++ b/handbook/src/routes/v1000.0.0/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.0.0`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.1.0/architecture/+page.md
+++ b/handbook/src/routes/v1000.1.0/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.1.0 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.1.0 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.1.0/introduction/+page.md
+++ b/handbook/src/routes/v1000.1.0/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.1.0 is and what changed from v1000.0.0
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,13 +25,13 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.0.0
 
-v1000.1.0 is a minor release adding one new primitive:
+<Version /> is a minor release adding one new primitive:
 
 - `lens()` added for two-way bindings to nested properties of state objects
 
 No breaking changes. All existing v1000.0.0 code works without modification.
 
-See the [migration guide](/v1000.1.0/migration) for details.
+See the <VersionLink path="/migration">migration guide</VersionLink> for details.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.1.0/llms/+page.md
+++ b/handbook/src/routes/v1000.1.0/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.1.0`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.1.0/select/+page.md
+++ b/handbook/src/routes/v1000.1.0/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.1.0/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.1.1/architecture/+page.md
+++ b/handbook/src/routes/v1000.1.1/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.1.1 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.1.1 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.1.1/introduction/+page.md
+++ b/handbook/src/routes/v1000.1.1/introduction/+page.md
@@ -1,7 +1,11 @@
 ---
 title: Introduction
-description: What Beacon v1000.1.1 is and what changed from v1000.1.0
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.1.0
 
-v1000.1.1 is a patch release. No API changes. Fixed package entry points (`main` and `types` paths in `package.json`).
+<Version /> is a patch release. No API changes. Fixed package entry points (`main` and `types` paths in `package.json`).
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.1.1/llms/+page.md
+++ b/handbook/src/routes/v1000.1.1/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.1.1`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.1.1/select/+page.md
+++ b/handbook/src/routes/v1000.1.1/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.1.1/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.2.0/architecture/+page.md
+++ b/handbook/src/routes/v1000.2.0/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.2.0 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.2.0 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.2.0/introduction/+page.md
+++ b/handbook/src/routes/v1000.2.0/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.2.0 is and what changed from v1000.1.1
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +25,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.1.1
 
-v1000.2.0 adds custom equality functions to `state()` and `protectedState()`. Pass an optional second argument to control when subscribers are notified. See the [migration guide](/v1000.2.0/migration).
+<Version /> adds custom equality functions to `state()` and `protectedState()`. Pass an optional second argument to control when subscribers are notified. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.2.0/llms/+page.md
+++ b/handbook/src/routes/v1000.2.0/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.2.0`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.2.0/select/+page.md
+++ b/handbook/src/routes/v1000.2.0/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.2.0/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.2.1/architecture/+page.md
+++ b/handbook/src/routes/v1000.2.1/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.2.1 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.2.1 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.2.1/introduction/+page.md
+++ b/handbook/src/routes/v1000.2.1/introduction/+page.md
@@ -1,7 +1,11 @@
 ---
 title: Introduction
-description: What Beacon v1000.2.1 is and what changed from v1000.2.0
+description: Introduction to Beacon
 ---
+
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.2.0
 
-Patch release. Updated build tooling (Biome, TypeScript config). No API changes. See the [migration guide](/v1000.2.1/migration).
+Patch release. Updated build tooling (Biome, TypeScript config). No API changes. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.2.1/llms/+page.md
+++ b/handbook/src/routes/v1000.2.1/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.2.1`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.2.1/select/+page.md
+++ b/handbook/src/routes/v1000.2.1/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.2.1/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.2.2/architecture/+page.md
+++ b/handbook/src/routes/v1000.2.2/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.2.2 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.2.2 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.2.2/introduction/+page.md
+++ b/handbook/src/routes/v1000.2.2/introduction/+page.md
@@ -1,7 +1,11 @@
 ---
 title: Introduction
-description: What Beacon v1000.2.2 is and what changed from v1000.2.1
+description: Introduction to Beacon
 ---
+
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.2.1
 
-`Unsubscribe` type is now exported. You can import it for explicit typing of effect cleanup functions. `STATE_ID` is now a named unique symbol. See the [migration guide](/v1000.2.2/migration).
+`Unsubscribe` type is now exported. You can import it for explicit typing of effect cleanup functions. `STATE_ID` is now a named unique symbol. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.2.2/llms/+page.md
+++ b/handbook/src/routes/v1000.2.2/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.2.2`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.2.2/select/+page.md
+++ b/handbook/src/routes/v1000.2.2/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.2.2/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.2.3/architecture/+page.md
+++ b/handbook/src/routes/v1000.2.3/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.2.3 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.2.3 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.2.3/introduction/+page.md
+++ b/handbook/src/routes/v1000.2.3/introduction/+page.md
@@ -1,7 +1,11 @@
 ---
 title: Introduction
-description: What Beacon v1000.2.3 is and what changed from v1000.2.2
+description: Introduction to Beacon
 ---
+
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.2.2
 
-Patch release. CI and repository configuration changes. No API changes. See the [migration guide](/v1000.2.3/migration).
+Patch release. CI and repository configuration changes. No API changes. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.2.3/llms/+page.md
+++ b/handbook/src/routes/v1000.2.3/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.2.3`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.2.3/select/+page.md
+++ b/handbook/src/routes/v1000.2.3/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.2.3/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.2.4/architecture/+page.md
+++ b/handbook/src/routes/v1000.2.4/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.2.4 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.2.4 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.2.4/introduction/+page.md
+++ b/handbook/src/routes/v1000.2.4/introduction/+page.md
@@ -1,7 +1,11 @@
 ---
 title: Introduction
-description: What Beacon v1000.2.4 is and what changed from v1000.2.3
+description: Introduction to Beacon
 ---
+
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.2.3
 
-Internal performance optimization. Batch flush now swaps collection references instead of copying, avoiding array allocations. No API changes. See the [migration guide](/v1000.2.4/migration).
+Internal performance optimization. Batch flush now swaps collection references instead of copying, avoiding array allocations. No API changes. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.2.4/llms/+page.md
+++ b/handbook/src/routes/v1000.2.4/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.2.4`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.2.4/select/+page.md
+++ b/handbook/src/routes/v1000.2.4/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.2.4/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.2.5/architecture/+page.md
+++ b/handbook/src/routes/v1000.2.5/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.2.5 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.2.5 is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~633 lines of TypeScript, organized as a `StateImpl` class with static methods. This page covers the internals.
 
 ## StateImpl class
 

--- a/handbook/src/routes/v1000.2.5/introduction/+page.md
+++ b/handbook/src/routes/v1000.2.5/introduction/+page.md
@@ -1,7 +1,11 @@
 ---
 title: Introduction
-description: What Beacon v1000.2.5 is and what changed from v1000.2.4
+description: Introduction to Beacon
 ---
+
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +24,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.2.4
 
-Patch release. README restructured. No API changes. See the [migration guide](/v1000.2.5/migration).
+Patch release. README restructured. No API changes. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.2.5/llms/+page.md
+++ b/handbook/src/routes/v1000.2.5/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.2.5`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.2.5/select/+page.md
+++ b/handbook/src/routes/v1000.2.5/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.2.5/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.3.0/architecture/+page.md
+++ b/handbook/src/routes/v1000.3.0/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.3.0 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.3.0 is ~544 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~544 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
 
 ## Standalone functions
 

--- a/handbook/src/routes/v1000.3.0/introduction/+page.md
+++ b/handbook/src/routes/v1000.3.0/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.3.0 is and what changed from v1000.2.5
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +25,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.2.5
 
-v1000.3.0 decomposes the `StateImpl` class into standalone functions for tree-shaking. Types are now `export type` only. No runtime behavioral changes. ~544 LOC. See the [migration guide](/v1000.3.0/migration).
+<Version /> decomposes the `StateImpl` class into standalone functions for tree-shaking. Types are now `export type` only. No runtime behavioral changes. ~544 LOC. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.3.0/llms/+page.md
+++ b/handbook/src/routes/v1000.3.0/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.3.0`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.3.0/select/+page.md
+++ b/handbook/src/routes/v1000.3.0/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.3.0/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.3.1/architecture/+page.md
+++ b/handbook/src/routes/v1000.3.1/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.3.1 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.3.1 is ~480 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~480 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
 
 ## Standalone functions
 

--- a/handbook/src/routes/v1000.3.1/introduction/+page.md
+++ b/handbook/src/routes/v1000.3.1/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.3.1 is and what changed from v1000.3.0
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +25,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.3.0
 
-v1000.3.1 reduces allocations in three hot paths: `protectedState` reader caching, `stateTracking` Set reuse on effect re-runs, and index-based iteration in `lens` path updates. Nested effect disposal now fully cleans up child references. No API or behavioral changes. ~480 LOC. See the [migration guide](/v1000.3.1/migration).
+<Version /> reduces allocations in three hot paths: `protectedState` reader caching, `stateTracking` Set reuse on effect re-runs, and index-based iteration in `lens` path updates. Nested effect disposal now fully cleans up child references. No API or behavioral changes. ~480 LOC. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.3.1/llms/+page.md
+++ b/handbook/src/routes/v1000.3.1/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.3.1`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.3.1/select/+page.md
+++ b/handbook/src/routes/v1000.3.1/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.3.1/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.

--- a/handbook/src/routes/v1000.3.2/architecture/+page.md
+++ b/handbook/src/routes/v1000.3.2/architecture/+page.md
@@ -1,9 +1,13 @@
 ---
 title: Architecture
-description: How Beacon v1000.3.2 works internally
+description: How Beacon works internally
 ---
 
-Beacon v1000.3.2 is ~489 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
+Beacon <Version /> is ~489 lines of TypeScript, organized as standalone top-level functions. The `StateImpl` class from prior versions has been eliminated entirely. This page covers the internals.
 
 ## Standalone functions
 

--- a/handbook/src/routes/v1000.3.2/introduction/+page.md
+++ b/handbook/src/routes/v1000.3.2/introduction/+page.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction
-description: What Beacon v1000.3.2 is and what changed from v1000.3.1
+description: Introduction to Beacon
 ---
+
+<script>
+import Version from '$lib/components/Version.svelte'
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
 
 Beacon is a reactive dependency graph runtime for Node.js. It tracks which values each function reads and re-runs that function when those values change.
 
@@ -20,7 +25,7 @@ When you read a signal inside an effect, Beacon records the dependency. When the
 
 ## Changes from v1000.3.1
 
-v1000.3.2 adds a proto-key denylist to `lens()` path extraction. Accessor paths that traverse `__proto__`, `constructor`, or `prototype` are silently rejected as a defense-in-depth measure against prototype pollution. No API or behavioral changes for legitimate use. See the [migration guide](/v1000.3.2/migration).
+<Version /> adds a proto-key denylist to `lens()` path extraction. Accessor paths that traverse `__proto__`, `constructor`, or `prototype` are silently rejected as a defense-in-depth measure against prototype pollution. No API or behavioral changes for legitimate use. See the <VersionLink path="/migration">migration guide</VersionLink>.
 
 ## Constraints
 

--- a/handbook/src/routes/v1000.3.2/llms/+page.md
+++ b/handbook/src/routes/v1000.3.2/llms/+page.md
@@ -3,6 +3,10 @@ title: LLM Documentation
 description: Plain-text endpoints for referencing Beacon docs in LLM conversations
 ---
 
+<script>
+import Version from '$lib/components/Version.svelte'
+</script>
+
 ## Overview
 
 The Beacon handbook is available as plain text at every version. These endpoints follow the [llms.txt](https://llmstxt.org/) convention and return content that LLMs can read directly.
@@ -16,7 +20,7 @@ The Beacon handbook is available as plain text at every version. These endpoints
 | `/{version}/llms-full.txt` | All pages concatenated into one document |
 | `/{version}/{page}.md` | Single page as raw Markdown |
 
-Replace `{version}` with a version number (e.g. `v1000.3.1`) or `latest`.
+Replace `{version}` with a version number (e.g. `<Version />`) or `latest`.
 
 ## Examples
 

--- a/handbook/src/routes/v1000.3.2/select/+page.md
+++ b/handbook/src/routes/v1000.3.2/select/+page.md
@@ -3,6 +3,10 @@ title: Select
 description: Subscribe to a computed slice of state
 ---
 
+<script>
+import VersionLink from '$lib/components/VersionLink.svelte'
+</script>
+
 ## API
 
 ```typescript
@@ -117,4 +121,4 @@ For large state objects where you care about one property, `select()` avoids the
 - `select()` returns `ReadOnlyState<R>` — read a slice, cannot write back
 - `lens()` returns `State<K>` — read and write a slice, with immutable updates propagated to the source
 
-Use `select()` when you only need to observe a property. Use [`lens()`](/v1000.3.1/lens) when you need two-way binding to a nested property.
+Use `select()` when you only need to observe a property. Use <VersionLink path="/lens">`lens()`</VersionLink> when you need two-way binding to a nested property.


### PR DESCRIPTION
## Summary

- Add `resolveVersionLabel()` to derive actual version label from URL prefix
- Add `Version.svelte` and `VersionLink.svelte` components that read version from Svelte context
- Set version context in `DocLayout.svelte` so all mdsvex pages can access it
- Replace hardcoded version strings across architecture (13), introduction (13), select (12), and llms (14) pages
- Historical references to prior versions stay hardcoded

Closes #93

## Test plan

- [x] `npm run check` passes (0 errors)
- [x] Handbook builds successfully (`cd handbook && npm run build`)
- [ ] Spot-check `/latest`, `/v1000.3.2`, and `/v1000.1.0` pages render correct version