### PR TITLE
perf(core): reuse Sets in notification loop instead of allocating per flush

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ type State<T> = ReadOnlyState<T> & WriteableState<T>
 
 // Module-level reactive state
 let currentSubscriber: Subscriber | null = null
-let pendingSubscribers: Set<Subscriber> = new Set<Subscriber>()
+const flushing: Set<Subscriber> = new Set<Subscriber>()
+const queued: Set<Subscriber> = new Set<Subscriber>()
+let pendingSubscribers: Set<Subscriber> = queued
 let isNotifying = false
 let batchDepth = 0
 let deferredEffectCreations: Subscriber[] = []
@@ -48,11 +50,12 @@ const notifySubscribers = (): void => {
 	try {
 		while (pendingSubscribers.size > 0) {
 			const subscribers = pendingSubscribers
-			pendingSubscribers = new Set()
+			pendingSubscribers = subscribers === queued ? flushing : queued
 
 			for (const effect of subscribers) {
 				effect()
 			}
+			subscribers.clear()
 		}
 	} finally {
 		isNotifying = false


### PR DESCRIPTION
Closes #64

## Summary

- Replace `new Set()` allocation on every flush iteration with a double-buffer pattern using two pre-allocated Sets (`flushing`/`queued`)
- After iterating a buffer, `.clear()` it so it's ready for reuse on the next iteration
- Eliminates GC pressure from short-lived Set allocations under cascading-update workloads

## Benchmark

Derive chain depth=10, 100k iterations per batch:

| | Avg | Min |
|---|---|---|
| Before (`new Set` per flush) | 3.405ms | 2.389ms |
| After (double-buffer) | 2.191ms | 1.467ms |

~38% improvement.

## Test plan

- [x] Biome lint passes
- [x] TypeScript compiles with no errors
- [x] All 117 tests pass
- [x] Benchmarked before/after