### PR TITLE
perf(core): eliminate backing state allocation in derive and select

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -232,26 +232,37 @@ const executeBatch = <T>(fn: () => T): T => {
 const createDerive = <T>(computeFn: () => T): ReadOnlyState<T> => {
 	let cachedValue: T = undefined as unknown as T
 	let initialized = false
-	const valueState = createState<T | undefined>(undefined)
+	const subscribers = new Set<Subscriber>()
 
 	createEffect(function deriveEffect(): void {
 		const newValue = computeFn()
 
 		if (!(initialized && Object.is(cachedValue, newValue))) {
 			cachedValue = newValue
-			valueState.set(newValue)
+
+			for (const sub of subscribers) {
+				pendingSubscribers.add(sub)
+			}
+			if (batchDepth === 0 && !isNotifying) {
+				notifySubscribers()
+			}
 		}
 
 		initialized = true
 	})
 
 	return function deriveGetter(): T {
+		const currentEffect = currentSubscriber
+		if (currentEffect) {
+			subscribers.add(currentEffect)
+			getOrCreate(subscriberDependencies, currentEffect, () => new Set()).add(subscribers)
+		}
+
 		if (!initialized) {
 			cachedValue = computeFn()
 			initialized = true
-			valueState.set(cachedValue)
 		}
-		return valueState() as T
+		return cachedValue
 	}
 }
 
@@ -263,7 +274,7 @@ const createSelect = <T, R>(
 	let initialized = false
 	let lastSelectedValue: R | undefined
 	let lastSourceValue: T | undefined
-	const valueState = createState<R | undefined>(undefined)
+	const subscribers = new Set<Subscriber>()
 
 	createEffect(function selectEffect(): void {
 		const sourceValue = source()
@@ -280,18 +291,29 @@ const createSelect = <T, R>(
 		}
 
 		lastSelectedValue = newSelectedValue
-		valueState.set(newSelectedValue)
 		initialized = true
+
+		for (const sub of subscribers) {
+			pendingSubscribers.add(sub)
+		}
+		if (batchDepth === 0 && !isNotifying) {
+			notifySubscribers()
+		}
 	})
 
 	return function selectGetter(): R {
+		const currentEffect = currentSubscriber
+		if (currentEffect) {
+			subscribers.add(currentEffect)
+			getOrCreate(subscriberDependencies, currentEffect, () => new Set()).add(subscribers)
+		}
+
 		if (!initialized) {
 			lastSourceValue = source()
 			lastSelectedValue = selectorFn(lastSourceValue)
-			valueState.set(lastSelectedValue)
 			initialized = true
 		}
-		return valueState() as R
+		return lastSelectedValue as R
 	}
 }
 


### PR DESCRIPTION
Closes #73

## Summary

- Replace internal `createState` in `createDerive` and `createSelect` with a direct value slot and a `Set<Subscriber>` for downstream tracking
- Eliminates one full state allocation (subscribers Set, stateId Symbol, closures) per derive/select instance
- Removes unnecessary notification cycle on first lazy read (no external subscriber can exist yet)
- Subscriber registration and cleanup still works correctly via `subscriberDependencies`

## Benchmark

10k signal allocation:

| | Before (min) | After (min) | Change |
|---|---|---|---|
| derive allocation | 20.674ms | 15.348ms | -26% |
| select allocation | 20.862ms | 17.645ms | -15% |
| derive chain propagation | 1.489ms | 1.506ms | neutral |

## Test plan

- [x] Biome lint passes
- [x] TypeScript compiles with no errors
- [x] All 117 tests pass
- [x] Benchmarked before/after