### PR TITLE
fix(handbook): redirect root to /latest instead of current version

### DIFF
--- a/handbook/src/routes/+page.ts
+++ b/handbook/src/routes/+page.ts
@@ -1,7 +1,6 @@
 import { redirect } from '@sveltejs/kit'
 import { resolveHref } from '$lib/resolve-href'
-import { currentVersion } from '$lib/versions'
 
 export function load(): never {
-	redirect(307, resolveHref(currentVersion.prefix))
+	redirect(307, resolveHref('/latest'))
 }


### PR DESCRIPTION
## Summary

- Root page (`/`) now redirects to `/latest` instead of `/v1000.3.2`
- The redirect was using `currentVersion.prefix` (the version with `current: true`) since the initial handbook backport in #47

## Test plan

- [x] Svelte check passes (0 errors)
- [x] Biome passes