### PR TITLE
docs(api): add JSDoc and module docs for JSR score

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
+	"description": "Lightweight reactive state management for Node.js backends. Proxy-based dependency tracking with zero dependencies.",
 	"exports": {
 		".": "./src/index.ts",
 		"./hooks": "./src/hooks/index.ts"

--- a/src/hooks/compose.ts
+++ b/src/hooks/compose.ts
@@ -1,5 +1,6 @@
 import type { HookFunction, SingleOrArray } from '../types.ts'
 
+/** Compose one or more hook functions into a single hook. Errors in individual hooks are silently caught. */
 export function composeHook<Args extends unknown[]>(
 	hook: SingleOrArray<HookFunction<Args>> | undefined
 ): HookFunction<Args> | undefined {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Hook types and composition utility for Beacon's instrumentation system.
+ *
+ * @module
+ */
 export type {
 	BatchHooks,
 	DeriveHooks,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,22 @@
-// Beacon - reactive state management system
+/**
+ * Beacon — reactive dependency graph runtime for Node.js backends.
+ *
+ * Proxy-based per-property tracking. Reads are recorded automatically,
+ * writes propagate through the dependency graph. Zero dependencies.
+ *
+ * @module
+ */
 import { composeHook } from './hooks/compose.ts'
 import type { BatchHooks, DeriveHooks, EffectHooks, HookFunction, StateHooks } from './types.ts'
 
-// Type definitions
+/** Disposal function returned by {@linkcode effect}. Calling it removes the effect and cleans up its dependencies. */
 export type Unsubscribe = () => void
+/** Function signature accepted by {@linkcode effect}. */
 export type EffectCallback = () => void
+/** Optional name for an effect, used in hook callbacks for identification. */
 export type EffectName = string
 
+/** Value returned by {@linkcode derive}. Set `reactive` to `false` to dispose. */
 export type ComputedValue<T> = {
 	readonly value: T | undefined | null
 	reactive: boolean
@@ -760,6 +770,7 @@ const HOOKLESS_HANDLER: ProxyHandler<ProxyTarget> = {
 	set: createSetHandler(undefined),
 }
 
+/** Wrap an object in a reactive Proxy. Property reads are tracked, writes notify subscribers. */
 export function state<T extends object>(initial: T, hooks?: StateHooks<T>): T {
 	if (initial === null || initial === undefined || typeof initial !== 'object') return initial
 
@@ -1103,6 +1114,7 @@ function registerChildEffect(eff: EffectFunction): void {
 	children.add(eff)
 }
 
+/** Run a function whenever its tracked dependencies change. Returns an {@linkcode Unsubscribe} disposal function. */
 export function effect(fn: EffectCallback, name?: EffectName, hooks?: EffectHooks): Unsubscribe {
 	const onRun = composeHook(hooks?.onRun)
 	const onDispose = composeHook(hooks?.onDispose)
@@ -1192,6 +1204,7 @@ function handleBatchError(
 	}
 }
 
+/** Group multiple state mutations so effects flush once at the outermost batch boundary. */
 export function batch<T>(fn: () => T, hooks?: BatchHooks): T {
 	if (!hooks) {
 		batchDepth++
@@ -1328,6 +1341,7 @@ function runDeriveWithErrorHandling<T>(
 	}
 }
 
+/** Eagerly compute a value from reactive dependencies. Returns a {@linkcode ComputedValue} — set `reactive` to `false` to dispose. */
 export function derive<T>(computeFn: () => T, hooks?: DeriveHooks<T>): ComputedValue<T> {
 	const onCompute = composeHook(hooks?.onCompute)
 	const onCacheHit = composeHook(hooks?.onCacheHit)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
+/** A hook callback that receives typed arguments. */
 export type HookFunction<Args extends unknown[]> = (...args: Args) => void
+/** Accept a single value or an array of values. */
 export type SingleOrArray<T> = T | T[]
 
+/** Hooks for {@linkcode batch}. */
 export interface BatchHooks {
 	onBatchEnd?: SingleOrArray<
 		HookFunction<
@@ -26,6 +29,7 @@ export interface BatchHooks {
 	>
 }
 
+/** Hooks for {@linkcode derive}. */
 export interface DeriveHooks<T = unknown> {
 	onCacheHit?: SingleOrArray<
 		HookFunction<
@@ -60,6 +64,7 @@ export interface DeriveHooks<T = unknown> {
 	>
 }
 
+/** Hooks for {@linkcode effect}. */
 export interface EffectHooks {
 	onDependencyAdd?: SingleOrArray<
 		HookFunction<
@@ -109,6 +114,7 @@ export interface EffectHooks {
 	>
 }
 
+/** Hooks for {@linkcode state}. */
 export interface StateHooks<T = unknown> {
 	onDelete?: SingleOrArray<
 		HookFunction<


### PR DESCRIPTION
## Summary

- Add `@module` JSDoc to both package entrypoints (`src/index.ts`, `src/hooks/index.ts`)
- Add JSDoc to all exported types, interfaces, and functions (0/5 → 5/5 symbol coverage)
- Add `description` field to `jsr.json`

Addresses two failing JSR score checks: "Has module docs in all entrypoints" and "Has docs for most symbols."

## Test plan

- [x] `biome check` clean
- [x] `tsc --noEmit` zero errors
- [x] `npm test` 193/193 passing
- [x] `npx jsr publish --dry-run --allow-dirty` succeeds with no slow types