### PR TITLE
feat(ci): check-action-versions v2 pilot

### DIFF
--- a/.github/workflows/check-action-versions-v2.yml
+++ b/.github/workflows/check-action-versions-v2.yml
@@ -1,0 +1,27 @@
+name: Check Action Versions (v2 pilot)
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '30 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: nerdalytics/check-action-versions/.github/workflows/check-action-versions.yml@v1
+    with:
+      committer-name: nerdalytics
+      committer-email: 97166791+nerdalytics@users.noreply.github.com
+      commit-prefix: 'chore(core):'
+      branch-name: update-github-actions-v2
+      issue-title: 'Security: Outdated GitHub Actions detected (v2 pilot)'
+      pr-labels: 'security,dependencies'
+      issue-labels: 'security,dependencies'
+      signing-method: ssh
+    secrets:
+      GH_PAT: ${{ secrets.ACTION_UPDATER_PAT }}
+      SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+      SIGNING_PASSPHRASE: ${{ secrets.SSH_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
Parallel pilot of the new reusable workflow at `nerdalytics/check-action-versions@v1`. Keeps existing `check-action-versions.yml` untouched. Phase 2 of the rollout plan.

Deliberate collision avoidance vs existing workflow:
- Filename: `check-action-versions-v2.yml`
- Cron: `30 9 * * 1` (30-min offset)
- `branch-name: update-github-actions-v2`
- `issue-title: ... (v2 pilot)`

These overrides get removed in Phase 3 cutover once pilot is verified.

Do not merge yet — requires explicit Phase 2 verification first (manual dispatch, diff vs old workflow output).