### PR TITLE
fix(ci): update check-action-versions v2 caller to composite form

### DIFF
--- a/.github/workflows/check-action-versions-v2.yml
+++ b/.github/workflows/check-action-versions-v2.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           token: ${{ secrets.ACTION_UPDATER_PAT }}
 
-      - uses: nerdalytics/check-action-versions@v1
+      - uses: nerdalytics/check-action-versions@29928de61014fcbeb70f5d258abb889a1658863c # v1
         with:
           committer-name: nerdalytics
           committer-email: 97166791+nerdalytics@users.noreply.github.com

--- a/.github/workflows/check-action-versions-v2.yml
+++ b/.github/workflows/check-action-versions-v2.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           token: ${{ secrets.ACTION_UPDATER_PAT }}
 
-      - uses: nerdalytics/check-action-versions@29928de61014fcbeb70f5d258abb889a1658863c # v1
+      - uses: nerdalytics/check-action-versions@3c702505657a6f6bc0eafe3f65dc673dec7efb4a # v1
         with:
           committer-name: nerdalytics
           committer-email: 97166791+nerdalytics@users.noreply.github.com

--- a/.github/workflows/check-action-versions-v2.yml
+++ b/.github/workflows/check-action-versions-v2.yml
@@ -11,17 +11,22 @@ on:
 
 jobs:
   check:
-    uses: nerdalytics/check-action-versions/.github/workflows/check-action-versions.yml@v1
-    with:
-      committer-name: nerdalytics
-      committer-email: 97166791+nerdalytics@users.noreply.github.com
-      commit-prefix: 'chore(core):'
-      branch-name: update-github-actions-v2
-      issue-title: 'Security: Outdated GitHub Actions detected (v2 pilot)'
-      pr-labels: 'security,dependencies'
-      issue-labels: 'security,dependencies'
-      signing-method: ssh
-    secrets:
-      GH_PAT: ${{ secrets.ACTION_UPDATER_PAT }}
-      SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
-      SIGNING_PASSPHRASE: ${{ secrets.SSH_SIGNING_KEY_PASSPHRASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.ACTION_UPDATER_PAT }}
+
+      - uses: nerdalytics/check-action-versions@v1
+        with:
+          committer-name: nerdalytics
+          committer-email: 97166791+nerdalytics@users.noreply.github.com
+          commit-prefix: 'chore(core):'
+          branch-name: update-github-actions-v2
+          issue-title: 'Security: Outdated GitHub Actions detected (v2 pilot)'
+          pr-labels: 'security,dependencies'
+          issue-labels: 'security,dependencies'
+          signing-method: ssh
+          gh-pat: ${{ secrets.ACTION_UPDATER_PAT }}
+          signing-key: ${{ secrets.SSH_SIGNING_KEY }}
+          signing-passphrase: ${{ secrets.SSH_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
The upstream action at `nerdalytics/check-action-versions@v1` was converted from a reusable workflow to a composite action (see [upstream PR #2](https://github.com/nerdalytics/check-action-versions/pull/2)). This updates beacon's caller to match.

Previously, on the first manual dispatch after PR #135 merged, the v2 pilot workflow failed with `invalid refspec` because the action tried to check out its own scripts using `${{ github.workflow_ref }}`, which inside a reusable workflow resolves to the caller's workflow ref rather than the callee's. Composite actions have `${{ github.action_path }}` and avoid the issue entirely.

Caller API changes:
- `jobs.check.uses:` removed; replaced with `runs-on: ubuntu-latest` + `steps:` with explicit `actions/checkout` and `uses: nerdalytics/check-action-versions@v1`
- `secrets:` block removed; secrets now ride in via `with:` as `gh-pat`, `signing-key`, `signing-passphrase` (still passed as `${{ secrets.X }}` for masking)

After merge, manually dispatch to validate end-to-end (Phase 2 of the rollout plan).