### PR TITLE
chore(ci): bump check-action-versions SHA pin

### DIFF
--- a/.github/workflows/check-action-versions.yml
+++ b/.github/workflows/check-action-versions.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           token: ${{ secrets.ACTION_UPDATER_PAT }}
 
-      - uses: nerdalytics/check-action-versions@3c702505657a6f6bc0eafe3f65dc673dec7efb4a # v1
+      - uses: nerdalytics/check-action-versions@800cc33a5c20ca73557cc7358a1c1f0b91f0a90a # v1
         with:
           committer-name: nerdalytics
           committer-email: 97166791+nerdalytics@users.noreply.github.com


### PR DESCRIPTION
Updates the v1 SHA pin from `3c70250` to `800cc33` to pick up fix PR #4 in the upstream action: silent handling of `releases/latest` 404s, so actions without published Releases (like the action itself, or setup-biome) don't emit confusing warnings containing the raw error JSON body.